### PR TITLE
fix(PropertySet): use GetFileNameWithoutExtension instead of .BaseName on string

### DIFF
--- a/Gatekeeper/Classes/Property.ps1
+++ b/Gatekeeper/Classes/Property.ps1
@@ -136,7 +136,7 @@ class PropertySet {
         }
         $ps = [PropertySet]::new($json)
         $ps.FilePath = (Resolve-Path $FilePath).Path
-        $ps.Name = $ps.FilePath.BaseName
+        $ps.Name = [System.IO.Path]::GetFileNameWithoutExtension($ps.FilePath)
         return $ps
     }
 


### PR DESCRIPTION
Fixes #14