### PR TITLE
fix(New-FeatureFlag): remove Mandatory from $Rules parameter

### DIFF
--- a/Gatekeeper/Public/New-FeatureFlag.ps1
+++ b/Gatekeeper/Public/New-FeatureFlag.ps1
@@ -55,7 +55,7 @@ function New-FeatureFlag {
         $Author = $env:USERNAME,
         [Effect]
         $DefaultEffect = [Effect]::Warn,
-        [Parameter(Mandatory, ValueFromPipeline)]
+        [Parameter(ValueFromPipeline)]
         [Rule[]]
         $Rules = @(),
         [ValidateScript({


### PR DESCRIPTION
## Summary

`` in `New-FeatureFlag` is declared `[Parameter(Mandatory)]` and simultaneously initialized to ` = @()`. PSScriptAnalyzer flags this as `PSAvoidDefaultValueForMandatoryParameter`. A Mandatory parameter with a default value is a contradiction — PowerShell ignores the default and prompts for input instead.

Since feature flags are commonly created with no rules initially (rules are added later), Mandatory is almost certainly wrong here.

## Fix

```powershell
# Before
[Parameter(Mandatory, ValueFromPipeline)]
[Rule[]]$Rules = @(),

# After
[Parameter(ValueFromPipeline)]
[Rule[]]$Rules = @(),
```

## File changed
- `Gatekeeper/Public/New-FeatureFlag.ps1` — 1 line

## Verification
- 1 commit
- GH007 compliant (commit email: 166608075+Jah-yee@users.noreply.github.com)
- Fixes #35

## Notes
- Found by Brent Tlackburn (as credited in issue)