### PR TITLE
docs: fix broken comment-based help examples (fixes #38)

### DIFF
--- a/Gatekeeper/Public/Test-Condition.ps1
+++ b/Gatekeeper/Public/Test-Condition.ps1
@@ -17,9 +17,14 @@ function Test-Condition {
     A condition to test which are part of rules.
 
     .EXAMPLE
-    $context = Get-DeviceContext
-    $propertySet = Read-PropertySet
-    $rule = $rules[0]
+    $propertySet = Read-PropertySet -Path .\props.json
+    $rule = New-Rule -Name 'MyRule' -Conditions @{
+        AllOf = @(
+            @{ Property = 'Hostname'; Operator = 'Equals'; Value = $env:COMPUTERNAME }
+        )
+    }
+    $context = Get-DefaultContext -PropertySet $propertySet
+    $context.Hostname = $env:COMPUTERNAME
     Test-Condition -Context $context -PropertySet $propertySet -Condition $rule
 
     This would return a true/false

--- a/Gatekeeper/Public/Test-FeatureFlag.ps1
+++ b/Gatekeeper/Public/Test-FeatureFlag.ps1
@@ -17,8 +17,11 @@
     The context to use to test against.
 
     .EXAMPLE
-    $context = Get-DeviceContext
-    Test-FeatureFlag -FeatureFlag '' -Context $context
+    $propertySet = Read-PropertySet -Path .\props.json
+    $flag = New-FeatureFlag -Name 'MyFeature'
+    $context = Get-DefaultContext -PropertySet $propertySet
+    $context.Hostname = $env:COMPUTERNAME
+    Test-FeatureFlag -FeatureFlag $flag -PropertySet $propertySet -Context $context
 
     This will test if the current device will pass the feature flag rules.
     #>


### PR DESCRIPTION
## Summary

Fixes issue #38 - broken examples in comment-based help.

## Changes

- **Test-FeatureFlag.ps1**: Replace non-existent `Get-DeviceContext` with proper setup (Read-PropertySet, New-FeatureFlag, Get-DefaultContext)
- **Test-Condition.ps1**: Replace non-existent `Get-DeviceContext` and `$rules[0]` with proper New-Rule + Get-DefaultContext setup

The old examples referenced `Get-DeviceContext` which does not exist in this module. The correct function is `Get-DefaultContext -PropertySet`.

## Testing

No code logic changed - only comment-based help examples in documentation. The module behavior is unchanged.

---

Closes #38