### PR TITLE
fix(evaluation): apply DefaultEffect only when no terminal rule fired (closes #10)

### DIFF
--- a/Gatekeeper/Public/Test-FeatureFlag.ps1
+++ b/Gatekeeper/Public/Test-FeatureFlag.ps1
@@ -40,8 +40,8 @@
     )
 
     begin {
-        $finalResult = $False
-        $config = Import-GatekeeperConfig
+        $finalResult = $false
+        $terminalHit = $false
     }
 
     process {
@@ -61,11 +61,13 @@
                     'Allow' {
                         Invoke-Logging -Effect 'Allow' -Rule $rule
                         $finalResult = $true
+                        $terminalHit = $true
                         break ruleLoop
                     }
                     'Deny' {
                         Invoke-Logging -Effect 'Deny' -Rule $rule
                         $finalResult = $false
+                        $terminalHit = $true
                         break ruleLoop
                     }
                     'Audit' {
@@ -85,7 +87,9 @@
     }
 
     end {
-        # Return a single bool
+        if (-not $terminalHit) {
+            $finalResult = $FeatureFlag.DefaultEffect -eq [Effect]::Allow
+        }
         return $finalResult
     }
 }


### PR DESCRIPTION
## Summary

- Adds `$terminalHit` flag to `Test-FeatureFlag` to track whether an Allow or Deny rule was reached
- In `end{}`, DefaultEffect is now evaluated only when no terminal rule matched — previously it was ignored entirely
- Removes dead `$config = Import-GatekeeperConfig` assignment from `begin{}`

## Test plan

- [ ] All 257 existing Pester tests pass
- [ ] `Test-FeatureFlag` with no matching rules now returns `$true` when `DefaultEffect = Allow` and `$false` when `DefaultEffect = Deny`
- [ ] A matched Allow/Deny rule still short-circuits evaluation and ignores DefaultEffect

Generated with Claude Code