### PR TITLE
fix(Classes): correct PropertySet.AddProperty hashtable key (closes #11)

### DIFF
--- a/Gatekeeper/Classes/Property.ps1
+++ b/Gatekeeper/Classes/Property.ps1
@@ -146,7 +146,7 @@ class PropertySet {
     }
 
     [PropertySet]AddProperty([PropertyDefinition]$Property) {
-        $this.Properties.Add($Property)
+        $this.Properties.Add($Property.Name, $Property)
         return $this
     }
 


### PR DESCRIPTION
## Summary
- `PropertySet.AddProperty` called `$this.Properties.Add($Property)` — passing only one argument to a hashtable's `Add` method, which requires both a key and a value.
- Fixed to `$this.Properties.Add($Property.Name, $Property)`.

## Test plan
- All 257 existing tests pass, 0 failures.