### PR TITLE
fix(ConditionGroup): add missing FromJson static method

### DIFF
--- a/Gatekeeper/Classes/FeatureFlag.ps1
+++ b/Gatekeeper/Classes/FeatureFlag.ps1
@@ -67,6 +67,11 @@ class ConditionGroup {
         }
     }
 
+    static [ConditionGroup] FromJson([string]$json) {
+        $data = ConvertFrom-JsonToHashtable -InputObject $json
+        return [ConditionGroup]::new($data)
+    }
+
     [boolean]IsValid() {
         # This check if for the top level condition group
         # For nested condition groups (AllOf, AnyOf, Not) the validity is not checked.

--- a/docs/en-US/New-FeatureFlag.md
+++ b/docs/en-US/New-FeatureFlag.md
@@ -14,7 +14,7 @@ Create a new feature flag.
 
 ```
 New-FeatureFlag [-Name] <String> [[-Description] <String>] [-Tags <String[]>] [-Version <Version>]
- [-Author <String>] [-DefaultEffect <Effect>] -Rules <Rule[]> [-FilePath <String>]
+ [-Author <String>] [-DefaultEffect <Effect>] [-Rules <Rule[]>] [-FilePath <String>]
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -132,7 +132,7 @@ Type: Rule[]
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: @()
 Accept pipeline input: True (ByValue)

--- a/tests/Test-Condition.tests.ps1
+++ b/tests/Test-Condition.tests.ps1
@@ -166,6 +166,12 @@ Describe 'Test-Condition' {
         }
         Test-Condition @script:testConditionSplat -Condition $condition | Should -BeFalse
     }
+    It 'Accepts a file path string via ConditionGroupTransformAttribute' {
+        $conditionPath = Join-Path $TestDrive 'Condition.json'
+        @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' } |
+            ConvertTo-Json | Set-Content -Path $conditionPath
+        Test-Condition @script:testConditionSplat -Condition $conditionPath | Should -BeTrue
+    }
     It 'Throws on context missing property' {
         $condition = @{
             Property = "Tier"


### PR DESCRIPTION
Fixes #12.

`ConditionGroupTransformAttribute.Transform` called `[ConditionGroup]::FromJson()` in its string/file-path branch, but `ConditionGroup` never had that static method — only `FeatureFlag` and `PropertySet` did. Any string path passed to a parameter decorated with `[ConditionGroupTransformAttribute()]` (e.g. `Test-Condition -Condition '.\mycondition.json'`) would throw `MethodNotFound`.

Added `ConditionGroup::FromJson([string]$json)` following the exact same pattern as the existing `FeatureFlag::FromJson`. Also added a Pester test that exercises the file-path branch end-to-end via `Test-Condition`.