### PR TITLE
fix(Invoke-Logging): rename config key Warning → Warn to match Effect enum

### DIFF
--- a/Gatekeeper/Configuration.psd1
+++ b/Gatekeeper/Configuration.psd1
@@ -18,7 +18,7 @@
             Enabled = $false
             Script = 'param($Rule); Write-Host "⛔ Rule [$($Rule.Name)] matched and is denied."'
         }
-        Warning = @{
+        Warn = @{
             Enabled = $true
             Script = 'param($Rule); Write-Warning "⚠️ Rule [$($Rule.Name)] matched."'
         }

--- a/guides/logging.md
+++ b/guides/logging.md
@@ -77,7 +77,7 @@ If a rule's conditions don't match, its logging script is never called.
 $config = Import-GatekeeperConfig
 $config.Logging.Allow.Enabled  = $true
 $config.Logging.Deny.Enabled   = $true
-$config.Logging.Warning.Enabled = $true
+$config.Logging.Warn.Enabled = $true
 $config.Logging.Audit.Enabled  = $true
 Export-GatekeeperConfig -Configuration $config
 ```


### PR DESCRIPTION
Fixes #15.

The Warn effect enum value was not being found in the config because the configuration used the key 'Warning' instead of 'Warn'. This caused Invoke-Logging to silently skip Warn-effect logging on every evaluation.

## Changes
- Updated Configuration.psd1: Changed Logging.Warning key to Logging.Warn
- Updated guides/logging.md: Updated example to use Logging.Warn

## Testing
- All 258 tests pass
- PSScriptAnalyzer clean