### PR TITLE
fix(logging): harden config-driven logging script execution

### DIFF
--- a/Gatekeeper/Configuration.psd1
+++ b/Gatekeeper/Configuration.psd1
@@ -7,6 +7,10 @@
     FilePaths = @{
         Schemas = "$PSScriptRoot\Schemas"
     }
+    # NOTE: A logging Script is executed as code with the caller's full
+    # privileges. It is a string that is either inline PowerShell code or a
+    # path to a local *.ps1 file (UNC/remote paths are rejected). Treat these
+    # files as trusted code. See guides/logging.md for details.
     Logging = @{
         Allow = @{
             # We leave this disabled by default to avoid cluttering the console

--- a/Gatekeeper/Private/Invoke-Logging.ps1
+++ b/Gatekeeper/Private/Invoke-Logging.ps1
@@ -8,15 +8,21 @@ function Invoke-Logging {
         $Rule
     )
     begin {
-        $config = Import-GatekeeperConfig
+        # Ensure the configuration (and the pre-parsed logging scriptblocks) are loaded.
+        $null = Import-GatekeeperConfig
     }
     process {
-        $logSettings = $config.Logging.$Effect
-
-        if ($logSettings.Enabled) {
-            $sb = [scriptblock]::Create($logSettings.Script)
-            & $sb -Rule $Rule
+        if (-not $script:GatekeeperLogging) {
+            return
         }
+        # Use the scriptblock already parsed and validated by Import-GatekeeperConfig.
+        # Re-creating it here from the raw config would re-introduce the double-parse
+        # and bypass that validation.
+        $logScript = $script:GatekeeperLogging[[string]$Effect]
+        if (-not $logScript) {
+            return
+        }
+        & $logScript -Rule $Rule
     }
 
 }

--- a/Gatekeeper/Public/Import-GatekeeperConfig.ps1
+++ b/Gatekeeper/Public/Import-GatekeeperConfig.ps1
@@ -36,21 +36,42 @@ function Import-GatekeeperConfig {
                     Write-Verbose "Logging level '$level' is disabled, skipping."
                     continue
                 }
-                # Handle if the script is a file path or string scriptblock
+                # A logging Script is executed as code with the caller's full
+                # privileges. It can be a literal scriptblock (set in-memory) or a
+                # string. A string ending in '.ps1' is treated as a path to a local
+                # script file; any other string is treated as inline PowerShell code.
+                # UNC / remote paths are rejected so the user-writable configuration
+                # file cannot pull a payload off the network.
                 $scriptContent = $script:GatekeeperConfiguration.Logging[$level].Script
-                if ($scriptContent -is [string]) {
-                    # Check if it's a file path
-                    if (Test-Path -Path $scriptContent -ErrorAction SilentlyContinue) {
-                        Write-Verbose "Loading logging script from file: $scriptContent"
-                        $script:GatekeeperLogging[$level] = [scriptblock]::Create((Get-Content -Path $scriptContent -Raw))
-                    } else {
-                        # Treat it as a script string and convert to scriptblock
-                        Write-Verbose "Converting string to script block for logging level: $level"
-                        $script:GatekeeperLogging[$level] = [scriptblock]::Create($scriptContent)
-                    }
-                } elseif ($scriptContent -is [scriptblock]) {
+                if ($scriptContent -is [scriptblock]) {
                     Write-Verbose "Using inline script block for logging level: $level"
                     $script:GatekeeperLogging[$level] = $scriptContent
+                } elseif ($scriptContent -is [string]) {
+                    if ([string]::IsNullOrWhiteSpace($scriptContent)) {
+                        Write-Warning "Logging level '$level' has an empty Script value; skipping."
+                        continue
+                    }
+                    if ($scriptContent -match '\.ps1\s*$') {
+                        $scriptPath = $scriptContent
+                        $parsedUri = $null
+                        $isRemotePath = $scriptPath -match '^(\\\\|//)' -or (
+                            [System.Uri]::TryCreate($scriptPath, [System.UriKind]::Absolute, [ref]$parsedUri) -and
+                            ($parsedUri.IsUnc -or $parsedUri.Scheme -ne 'file')
+                        )
+                        if ($isRemotePath) {
+                            Write-Warning "Logging level '$level' Script path '$scriptPath' is a UNC or remote path; refusing to load it."
+                            continue
+                        }
+                        if (-not (Test-Path -Path $scriptPath -PathType Leaf -ErrorAction SilentlyContinue)) {
+                            Write-Warning "Logging level '$level' Script path '$scriptPath' was not found; skipping."
+                            continue
+                        }
+                        Write-Verbose "Loading logging script from file: $scriptPath"
+                        $script:GatekeeperLogging[$level] = [scriptblock]::Create((Get-Content -Path $scriptPath -Raw))
+                    } else {
+                        Write-Verbose "Compiling inline logging script for level: $level"
+                        $script:GatekeeperLogging[$level] = [scriptblock]::Create($scriptContent)
+                    }
                 } else {
                     Write-Warning "No valid script found for logging level: $level"
                 }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Test-FeatureFlag -FeatureFlag $flag -PropertySet $props -Context $context
 - **No external runtime dependencies** -- just PowerShell and a JSON file
 - **Cross-platform** -- Windows, Linux, macOS
 
+## Security
+
+Logging `Script` values in your `Configuration.psd1` are **executed as code with the
+caller's full privileges** -- a `Script` string is either inline PowerShell that gets
+compiled and run, or a path to a local `.ps1` file that gets loaded and run (UNC /
+remote paths are rejected). Keep your configuration files (and any referenced `.ps1`
+scripts) writable only by trusted users. See
+[Logging](https://heyitsgilbert.github.io/Gatekeeper/guides/logging/) for details.
+
 ## Documentation
 
 | Topic | Description |

--- a/guides/logging.md
+++ b/guides/logging.md
@@ -15,20 +15,19 @@ Allow and Deny logging are disabled by default to avoid cluttering output during
 
 ## Configuring logging
 
-Logging is defined in your `Configuration.psd1`. Each effect has an `Enabled` flag and a `Script` that accepts a `$Rule` parameter.
+Logging is defined in your `Configuration.psd1`. Each effect has an `Enabled` flag and a `Script` that receives a `$Rule` parameter. Because the configuration is loaded through the [Configuration](https://www.powershellgallery.com/packages/Configuration) module's data-only parser, `Script` is always a **string** -- either inline PowerShell code, or a path to a local `.ps1` file (any string ending in `.ps1` is treated as a path).
 
-### Using a script block
+!!! danger "A `Script` runs as code"
+    A logging `Script` is executed with the **full privileges of whatever process loaded Gatekeeper** -- an inline string is compiled and run, and a `.ps1` path is loaded and run. Treat your `Configuration.psd1` files (and any `.ps1` they reference) as trusted code: keep them writable only by trusted users, and never point `Script` at a path you don't control. UNC / network paths (for example `\\server\share\evil.ps1`) are refused outright.
+
+### Using inline code
 
 ```powershell
 @{
     Logging = @{
         Audit = @{
             Enabled = $true
-            Script  = {
-                param($Rule)
-                "$([DateTime]::Now) - Audit: $($Rule.Name)" |
-                    Out-File 'C:\Logs\Gatekeeper.log' -Append
-            }
+            Script  = 'param($Rule); "$([DateTime]::Now) - Audit: $($Rule.Name)" | Out-File ''C:\Logs\Gatekeeper.log'' -Append'
         }
     }
 }
@@ -36,7 +35,7 @@ Logging is defined in your `Configuration.psd1`. Each effect has an `Enabled` fl
 
 ### Using a script file
 
-If you prefer to keep logging logic in a separate file, point `Script` to a `.ps1` path.
+To keep logging logic in a separate file, point `Script` to a local `.ps1` path.
 
 **`C:\Scripts\GatekeeperAudit.ps1`:**
 
@@ -60,7 +59,7 @@ param($Rule)
 ```
 
 !!! warning
-    When `Script` is a string, it must be a valid file path to a `.ps1` script that accepts a `$Rule` parameter. Gatekeeper will invoke the file directly.
+    A `Script` string ending in `.ps1` is loaded as a script file: it must already exist on a **local** path, and UNC / network paths are rejected. Any other string is compiled and executed as inline PowerShell. Either way the value runs with the caller's full privileges, so only put trusted code there.
 
 ## When logging runs
 


### PR DESCRIPTION
Fixes #16.

## Problem

Logging `Script` values from `Configuration.psd1` (which lives in user-writable
locations such as `$Env:LocalAppData\...\Gatekeeper\Configuration.psd1`) were
compiled and executed on every matching rule evaluation, and `Import-GatekeeperConfig`
dispatched "is this a file path or inline code?" based on `Test-Path` — which an
attacker controls. The `Test-Path` branch also accepted UNC paths, allowing a payload
to be pulled off the network. `Invoke-Logging` additionally re-created the scriptblock
from raw config, ignoring the copy already parsed by `Import-GatekeeperConfig`.

## Changes

- **`Invoke-Logging`** now executes `$script:GatekeeperLogging[$Effect]` — the
  scriptblock already parsed by `Import-GatekeeperConfig` — instead of re-compiling
  from raw config, removing the double-parse.
- **`Import-GatekeeperConfig`** now treats a `Script` *string* ending in `.ps1` as a
  path to a **local** script file: UNC / remote paths (`\…`, `//…`, non-`file://`
  URIs) are rejected, the file must already exist, and the dispatch no longer depends
  on attacker-controllable file existence. Any other string is compiled as inline code
  (unchanged, since `.psd1` config can only hold strings).
- **`Configuration.psd1`** — added a security note; default scripts unchanged.
- **Docs** — `README.md` gains a Security section; `guides/logging.md` documents that
  `Script` values run as code with the caller's privileges, and the example is fixed
  to use a string (a `.psd1` parsed by the Configuration module cannot hold scriptblock
  literals).

## Testing

- `.\build.ps1 -Task Test -OutputFormat Quiet` → Success, 258 passed / 0 failed / 5 skipped (pre-existing skips).
- PSScriptAnalyzer: no new findings (the one `Configuration.psd1` BOM warning pre-dates this change).
- Manually verified: default Audit logging still fires; UNC `.ps1`, remote-URL `.ps1`, and missing-file `Script` values are rejected with a warning and skipped; local `.ps1` files and inline strings still load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)