### PR TITLE
fix(transforms): prevent path traversal in argument transform attributes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,9 @@ Configuration path: `Gilbert Sanchez\Gatekeeper\Configuration.psd1`
         FeatureFlags = $null  # Defaults to machine-wide config location
         PropertySet = $null   # Defaults to machine-wide config location
     }
+    Security = @{
+        AllowUncPaths = $false  # Allow UNC file paths passed to commands
+    }
     Logging = @{
         Allow = @{ Enabled = $bool; Script = {param($Rule) ...} }
         Deny = @{ Enabled = $bool; Script = {param($Rule) ...} }

--- a/Gatekeeper/Classes/FeatureFlag.ps1
+++ b/Gatekeeper/Classes/FeatureFlag.ps1
@@ -192,6 +192,41 @@ class FeatureFlag {
     }
 }
 
+class GatekeeperPath {
+    # Validates a user-supplied string as a safe path to an existing JSON file.
+    # Rejects wildcard patterns, non-.json files, and UNC paths (unless enabled
+    # via the Security.AllowUncPaths configuration setting) so callers that accept
+    # untrusted flag names cannot be redirected to read arbitrary files. Returns
+    # the resolved provider path on success and throws otherwise.
+    static [string] ResolveJsonFilePath([string]$Path) {
+        if ([string]::IsNullOrWhiteSpace($Path)) {
+            throw "File path cannot be empty."
+        }
+        if ([System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters($Path)) {
+            throw "File path cannot contain wildcard characters: $Path"
+        }
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+            throw "File not found: $Path"
+        }
+        $resolved = (Resolve-Path -LiteralPath $Path).ProviderPath
+        if ([System.IO.Path]::GetExtension($resolved) -ne '.json') {
+            throw "File path must point to a .json file: $Path"
+        }
+        if (([uri]$resolved).IsUnc -and -not [GatekeeperPath]::AllowUncPaths()) {
+            throw "UNC file paths are not permitted unless enabled via the Security.AllowUncPaths configuration: $Path"
+        }
+        return $resolved
+    }
+
+    static [boolean] AllowUncPaths() {
+        try {
+            return [boolean](Import-GatekeeperConfig).Security.AllowUncPaths
+        } catch {
+            return $false
+        }
+    }
+}
+
 class FeatureFlagTransformAttribute : System.Management.Automation.ArgumentTransformationAttribute {
 
     ## Override the abstract method "Transform". This is where the user
@@ -204,12 +239,9 @@ class FeatureFlagTransformAttribute : System.Management.Automation.ArgumentTrans
                 [FeatureFlag]::new($inputData)
             }
             'System.String' {
-                if (Test-Path $inputData) {
-                    $json = Get-Content -Raw -Path $inputData
-                    [FeatureFlag]::FromJson($json)
-                } else {
-                    throw "Unknown string. If this is a file path, please check if it correct. $inputData"
-                }
+                $resolvedPath = [GatekeeperPath]::ResolveJsonFilePath($inputData)
+                $json = Get-Content -Raw -LiteralPath $resolvedPath
+                [FeatureFlag]::FromJson($json)
             }
             default {
                 throw "Cannot convert type to FeatureFlag: $($inputData.GetType().FullName)"
@@ -235,12 +267,9 @@ class ConditionGroupTransformAttribute : System.Management.Automation.ArgumentTr
                 [ConditionGroup]::new($inputData)
             }
             'System.String' {
-                if (Test-Path $inputData) {
-                    $json = Get-Content -Raw -Path $inputData
-                    [ConditionGroup]::FromJson($json)
-                } else {
-                    throw "Unknown string. If this is a file path, please check if it correct. $inputData"
-                }
+                $resolvedPath = [GatekeeperPath]::ResolveJsonFilePath($inputData)
+                $json = Get-Content -Raw -LiteralPath $resolvedPath
+                [ConditionGroup]::FromJson($json)
             }
             default {
                 throw "Cannot convert type to ConditionGroup: $($inputData.GetType().FullName)"

--- a/Gatekeeper/Configuration.psd1
+++ b/Gatekeeper/Configuration.psd1
@@ -7,6 +7,11 @@
     FilePaths = @{
         Schemas = "$PSScriptRoot\Schemas"
     }
+    Security = @{
+        # When $false, file paths passed to commands (e.g. Test-FeatureFlag,
+        # Test-Condition) may not be UNC paths. Set to $true to opt in.
+        AllowUncPaths = $false
+    }
     Logging = @{
         Allow = @{
             # We leave this disabled by default to avoid cluttering the console

--- a/tests/Test-Condition.tests.ps1
+++ b/tests/Test-Condition.tests.ps1
@@ -172,6 +172,23 @@ Describe 'Test-Condition' {
             ConvertTo-Json | Set-Content -Path $conditionPath
         Test-Condition @script:testConditionSplat -Condition $conditionPath | Should -BeTrue
     }
+    It 'Rejects a wildcard path via ConditionGroupTransformAttribute' {
+        {
+            Test-Condition @script:testConditionSplat -Condition (Join-Path $TestDrive '*.json')
+        } | Should -Throw -ExpectedMessage '*wildcard*'
+    }
+    It 'Rejects a non-JSON file path via ConditionGroupTransformAttribute' {
+        $notJson = Join-Path $TestDrive 'condition.txt'
+        'not json' | Set-Content -LiteralPath $notJson
+        {
+            Test-Condition @script:testConditionSplat -Condition $notJson
+        } | Should -Throw -ExpectedMessage '*must point to a .json file*'
+    }
+    It 'Rejects a missing file path via ConditionGroupTransformAttribute' {
+        {
+            Test-Condition @script:testConditionSplat -Condition (Join-Path $TestDrive 'missing.json')
+        } | Should -Throw -ExpectedMessage '*File not found:*'
+    }
     It 'Throws on context missing property' {
         $condition = @{
             Property = "Tier"

--- a/tests/Test-FeatureFlag.tests.ps1
+++ b/tests/Test-FeatureFlag.tests.ps1
@@ -31,4 +31,18 @@ Describe 'Test-FeatureFlag' {
             $Effect -eq 'Allow'
         } -Times 1
     }
+
+    It 'Rejects a wildcard feature flag path' {
+        {
+            Test-FeatureFlag -FeatureFlag (Join-Path $TestDrive '*.json') -PropertySet $script:propertySet -Context $script:context
+        } | Should -Throw -ExpectedMessage '*wildcard*'
+    }
+
+    It 'Rejects a non-JSON feature flag path' {
+        $notJson = Join-Path $TestDrive 'flag.txt'
+        'not json' | Set-Content -LiteralPath $notJson
+        {
+            Test-FeatureFlag -FeatureFlag $notJson -PropertySet $script:propertySet -Context $script:context
+        } | Should -Throw -ExpectedMessage '*must point to a .json file*'
+    }
 }


### PR DESCRIPTION
Fixes #18.

## Bug

`FeatureFlagTransformAttribute` and `ConditionGroupTransformAttribute` passed caller-supplied strings directly to `Test-Path $inputData` / `Get-Content -Path $inputData` — no `-LiteralPath`, no extension check, no path anchoring. Callers that accept flag names from external sources could be redirected to read arbitrary files (`'C:\Windows\System32\config\SAM'`, `'\attacker\share\flag.json'`), and wildcard globs (`'C:\Users\*\AppData\*.json'`) could probe the filesystem.

## Fix

- New `GatekeeperPath::ResolveJsonFilePath` static helper:
  - rejects wildcard patterns (`[WildcardPattern]::ContainsWildcardCharacters`)
  - requires an existing file via `Test-Path -LiteralPath -PathType Leaf`
  - requires a `.json` extension
  - rejects UNC paths unless opted in via the new `Security.AllowUncPaths` configuration setting (defaults to `$false`)
- Both transform attributes route `System.String` input through the helper and read with `Get-Content -Raw -LiteralPath`.
- Added `Security.AllowUncPaths` to `Configuration.psd1` (and documented it in `CLAUDE.md`).

The three example attacks are all blocked: SAM has no `.json` extension, the UNC share is rejected, the wildcard probe is rejected.

## Tests

`./build.ps1 -Task Test` — 263 passed, 0 failed, 5 skipped. Added regression tests in `tests/Test-Condition.tests.ps1` and `tests/Test-FeatureFlag.tests.ps1` covering wildcard, non-JSON, and missing-file rejection. PSScriptAnalyzer clean.

## Impact

String paths passed to `Test-FeatureFlag -FeatureFlag` / `Test-Condition -Condition` must now point to an existing `.json` file with no wildcards, and must not be UNC paths unless `Security.AllowUncPaths` is enabled. Hashtable and existing-object inputs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)