### PR TITLE
fix(Property): add regex timeout to PropertyDefinition.Validate

### DIFF
--- a/Gatekeeper/Classes/Property.ps1
+++ b/Gatekeeper/Classes/Property.ps1
@@ -83,9 +83,17 @@ class PropertyDefinition {
                     Write-Warning "Value for '$($this.Name)' is longer than MaxLength ($($this.Validation.MaxLength))"
                     return $false
                 }
-                if ($this.Validation.Pattern -and ($Value -notmatch $this.Validation.Pattern)) {
-                    Write-Warning "Value for '$($this.Name)' does not match pattern '$($this.Validation.Pattern)'"
-                    return $false
+                if ($this.Validation.Pattern) {
+                    try {
+                        $re = [regex]::new($this.Validation.Pattern, [System.Text.RegularExpressions.RegexOptions]::None, [TimeSpan]::FromMilliseconds(250))
+                        if (-not $re.IsMatch($Value)) {
+                            Write-Warning "Value for '$($this.Name)' does not match pattern '$($this.Validation.Pattern)'"
+                            return $false
+                        }
+                    } catch [System.Text.RegularExpressions.RegexMatchTimeoutException] {
+                        Write-Warning "Pattern evaluation timed out for '$($this.Name)'"
+                        return $false
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #19.

## Summary

`PropertyDefinition.Validate` evaluated user-supplied `Pattern` regexes from JSON via `-notmatch` with no timeout, allowing a catastrophic-backtracking pattern plus a crafted context value to hang `Test-FeatureFlag` indefinitely (availability risk).

## Fix

Compile the pattern with `[regex]::new(<pattern>, 'None', [TimeSpan]::FromMilliseconds(250))` and use `IsMatch`. On `RegexMatchTimeoutException`, emit a warning and fail validation (consistent with the module's safe-evaluation philosophy).

## Tests

`.\build.ps1 -Task Test -OutputFormat Quiet` — 258 passed, 0 failed, 5 skipped. PSScriptAnalyzer clean.

## Impact

No public API change. Pathological patterns now fail validation within ~250ms instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
