### PR TITLE
test(Test-Condition): add missing operator tests — GreaterThanOrEqual, LessThan, LessThanOrEqual

### DIFF
--- a/tests/Test-Condition.tests.ps1
+++ b/tests/Test-Condition.tests.ps1
@@ -55,6 +55,54 @@ Describe 'Test-Condition' {
         }
         Test-Condition @script:testConditionSplat -Condition $condition | Should -BeTrue
     }
+    It 'GreaterThanOrEqual returns true at exact boundary' {
+        $condition = @{
+            Property = "Percentage"
+            Operator = "GreaterThanOrEqual"
+            Value = 30
+        }
+        Test-Condition @script:testConditionSplat -Condition $condition | Should -BeTrue
+    }
+    It 'GreaterThanOrEqual returns false when value is above threshold' {
+        $condition = @{
+            Property = "Percentage"
+            Operator = "GreaterThanOrEqual"
+            Value = 31
+        }
+        Test-Condition @script:testConditionSplat -Condition $condition | Should -BeFalse
+    }
+    It 'LessThan returns true when value is below threshold' {
+        $condition = @{
+            Property = "Percentage"
+            Operator = "LessThan"
+            Value = 31
+        }
+        Test-Condition @script:testConditionSplat -Condition $condition | Should -BeTrue
+    }
+    It 'LessThan returns false at exact boundary (exclusive)' {
+        $condition = @{
+            Property = "Percentage"
+            Operator = "LessThan"
+            Value = 30
+        }
+        Test-Condition @script:testConditionSplat -Condition $condition | Should -BeFalse
+    }
+    It 'LessThanOrEqual returns true at exact boundary (inclusive)' {
+        $condition = @{
+            Property = "Percentage"
+            Operator = "LessThanOrEqual"
+            Value = 30
+        }
+        Test-Condition @script:testConditionSplat -Condition $condition | Should -BeTrue
+    }
+    It 'LessThanOrEqual returns false when value is above threshold' {
+        $condition = @{
+            Property = "Percentage"
+            Operator = "LessThanOrEqual"
+            Value = 29
+        }
+        Test-Condition @script:testConditionSplat -Condition $condition | Should -BeFalse
+    }
     It 'Can evaluate a $true bool with equals' {
         $condition = @{
             Property = "IsCompliant"


### PR DESCRIPTION
Fixes #21.

## Summary

Added test coverage for three comparison operators defined in the `Operator` enum and handled in `Test-Condition`'s switch statement:

- `GreaterThanOrEqual`: Tests at boundary (30 >= 30) and above boundary (30 >= 31)
- `LessThan`: Tests below threshold (30 < 31) and at boundary (30 < 30)
- `LessThanOrEqual`: Tests at boundary (30 <= 30) and above threshold (30 <= 29)

All tests verify boundary conditions, which are the most likely to have off-by-one errors.

## Tests

Added 6 new test cases to `tests/Test-Condition.tests.ps1`. All tests pass:

- 269 tests passed
- 0 tests failed
- 5 tests skipped