### PR TITLE
test(Test-TypedValue): add private function test suite

### DIFF
--- a/tests/Test-TypedValue.tests.ps1
+++ b/tests/Test-TypedValue.tests.ps1
@@ -1,0 +1,81 @@
+BeforeDiscovery {
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'Output'
+    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+    $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+    $outputModVerManifest = Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1"
+
+    # Remove all versions of the module from the session. Pester can't handle multiple versions.
+    Get-Module $env:BHProjectName | Remove-Module -Force -ErrorAction Ignore
+    Import-Module -Name $outputModVerManifest -Verbose:$false -ErrorAction Stop
+}
+Describe 'Test-TypedValue' {
+    Context 'WithPropertyDefinition parameter set' {
+        It 'delegates to PropertyDefinition.Validate for a valid value' {
+            InModuleScope $env:BHProjectName {
+                $prop = [PropertyDefinition]::new('Score', @{ Type = 'integer'; Validation = @{ Minimum = 1; Maximum = 10 } })
+                { Test-TypedValue -PropertyDefinition $prop -Value 5 } | Should -Not -Throw
+            }
+        }
+        It 'delegates to PropertyDefinition.Validate and does not throw for an invalid value' {
+            InModuleScope $env:BHProjectName {
+                $prop = [PropertyDefinition]::new('Score', @{ Type = 'integer'; Validation = @{ Minimum = 1; Maximum = 10 } })
+                { Test-TypedValue -PropertyDefinition $prop -Value 0 } | Should -Not -Throw
+            }
+        }
+    }
+    Context 'WithOutPropertyDefinition parameter set - integer constraints' {
+        It 'throws when value is below Minimum' {
+            InModuleScope $env:BHProjectName {
+                $validation = @{ Minimum = 1; Maximum = 10 }
+                { Test-TypedValue -Type 'integer' -Name 'Score' -Validation $validation -Value 0 } | Should -Throw
+            }
+        }
+        It 'throws when value is above Maximum' {
+            InModuleScope $env:BHProjectName {
+                $validation = @{ Minimum = 1; Maximum = 10 }
+                { Test-TypedValue -Type 'integer' -Name 'Score' -Validation $validation -Value 11 } | Should -Throw
+            }
+        }
+        It 'passes when value is within range' {
+            InModuleScope $env:BHProjectName {
+                $validation = @{ Minimum = 1; Maximum = 10 }
+                { Test-TypedValue -Type 'integer' -Name 'Score' -Validation $validation -Value 5 } | Should -Not -Throw
+            }
+        }
+    }
+    Context 'WithOutPropertyDefinition parameter set - string constraints' {
+        It 'throws when value is shorter than MinLength' {
+            InModuleScope $env:BHProjectName {
+                $validation = @{ MinLength = 5 }
+                { Test-TypedValue -Type 'string' -Name 'Tag' -Validation $validation -Value 'abc' } | Should -Throw
+            }
+        }
+        It 'throws when value is longer than MaxLength' {
+            InModuleScope $env:BHProjectName {
+                $validation = @{ MaxLength = 5 }
+                { Test-TypedValue -Type 'string' -Name 'Tag' -Validation $validation -Value 'toolongstring' } | Should -Throw
+            }
+        }
+        It 'throws when value does not match Pattern' {
+            InModuleScope $env:BHProjectName {
+                $validation = @{ Pattern = '^[a-z]+$' }
+                { Test-TypedValue -Type 'string' -Name 'Tag' -Validation $validation -Value 'ABC123' } | Should -Throw
+            }
+        }
+        It 'passes when value matches Pattern' {
+            InModuleScope $env:BHProjectName {
+                $validation = @{ Pattern = '^[a-z]+$' }
+                { Test-TypedValue -Type 'string' -Name 'Tag' -Validation $validation -Value 'abc' } | Should -Not -Throw
+            }
+        }
+    }
+    Context 'WithPropertyDefinition parameter set - no validation configured' {
+        It 'returns cleanly when PropertyDefinition has no Validation set' {
+            InModuleScope $env:BHProjectName {
+                $prop = [PropertyDefinition]::new('Score', @{ Type = 'integer' })
+                { Test-TypedValue -PropertyDefinition $prop -Value 999 } | Should -Not -Throw
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #23.

Adds a Pester test suite for the `Test-TypedValue` private function, which previously had zero direct test coverage.

**Tests added** (`tests/Test-TypedValue.tests.ps1`):
- `WithPropertyDefinition` parameter set: delegates to `PropertyDefinition.Validate()` (valid value passes; invalid value does not throw — Validate returns false and writes a warning)
- `WithPropertyDefinition` parameter set: returns cleanly when `PropertyDefinition` has no `Validation` set
- `WithOutPropertyDefinition` — integer: throws below `Minimum`, throws above `Maximum`, passes within range
- `WithOutPropertyDefinition` — string: throws shorter than `MinLength`, throws longer than `MaxLength`, throws on pattern mismatch, passes on pattern match

All 10 new tests pass; full suite 273 passed / 0 failed.