### PR TITLE
test(classes): add contract tests for class layer

### DIFF
--- a/Gatekeeper/Classes/FeatureFlag.ps1
+++ b/Gatekeeper/Classes/FeatureFlag.ps1
@@ -23,35 +23,43 @@ class ConditionGroup {
         if ($null -eq $data) {
             throw "Data cannot be null."
         }
-        # This should either have a single condition or a group of conditions
-        $groupKeys = @('AllOf', 'AnyOf', 'Not') | Where-Object { $data.ContainsKey($_) }
+        # Treat keys present but null as non-present (handles JSON round-trips where all
+        # class fields are serialized including null/default ones).
+        $groupKeys = @('AllOf', 'AnyOf', 'Not') | Where-Object { $data.ContainsKey($_) -and $null -ne $data[$_] }
         if ($groupKeys.Count -gt 1) {
             throw "ConditionGroup may only define one of: AllOf, AnyOf, Not. Got: $($groupKeys -join ', ')"
         }
-        if (($data.ContainsKey('AllOf') -or $data.ContainsKey('AnyOf') -or $data.ContainsKey('Not')) -and
-            ($data.ContainsKey('Property') -or $data.ContainsKey('Operator') -or $data.ContainsKey('Value'))) {
+        # Property presence (non-null) is the canonical signal for a flat/leaf condition.
+        # Operator is excluded from this check because its enum default ("Equals") is always
+        # serialized as a non-null string in JSON round-trips, making it unreliable as a signal.
+        $hasGroup = $groupKeys.Count -gt 0
+        $hasProperty = $data.ContainsKey('Property') -and $null -ne $data['Property']
+        if ($hasGroup -and $hasProperty) {
             throw "ConditionGroup with AllOf, AnyOf, or Not cannot also have Property, Operator, and Value defined."
         }
-        if ($data.ContainsKey('Property') -and
-            (-not $data.ContainsKey('Operator') -or -not $data.ContainsKey('Value'))) {
-            throw "ConditionGroup with Property must also have Operator and Value defined."
+        if ($hasProperty) {
+            $hasOperator = $data.ContainsKey('Operator') -and $null -ne $data['Operator']
+            $hasValue = $data.ContainsKey('Value') -and $null -ne $data['Value']
+            if (-not $hasOperator -or -not $hasValue) {
+                throw "ConditionGroup with Property must also have Operator and Value defined."
+            }
         }
-        if ($data.ContainsKey('Property')) {
+        if ($hasProperty) {
             $this.Property = $data.Property
         }
-        if ($data.ContainsKey('Operator')) {
+        if ($data.ContainsKey('Operator') -and $null -ne $data['Operator']) {
             $this.Operator = $data.Operator
         }
-        if ($data.ContainsKey('Value')) {
+        if ($data.ContainsKey('Value') -and $null -ne $data['Value']) {
             $this.Value = $data.Value
         }
-        if ($data.ContainsKey('AllOf')) {
+        if ($data.ContainsKey('AllOf') -and $null -ne $data['AllOf']) {
             $this.AllOf = $data.AllOf | ForEach-Object { [ConditionGroup]::new($_) }
         }
-        if ($data.ContainsKey('AnyOf')) {
+        if ($data.ContainsKey('AnyOf') -and $null -ne $data['AnyOf']) {
             $this.AnyOf = $data.AnyOf | ForEach-Object { [ConditionGroup]::new($_) }
         }
-        if ($data.ContainsKey('Not')) {
+        if ($data.ContainsKey('Not') -and $null -ne $data['Not']) {
             $this.Not = $data.Not | ForEach-Object { [ConditionGroup]::new($_) }
         }
     }
@@ -158,7 +166,18 @@ class FeatureFlag {
         $this.Name = $data.Name
         $this.Description = $data.Description
         $this.Tags = $data.Tags
-        $this.Version = $data.Version
+        if ($null -ne $data.Version) {
+            if ($data.Version -is [System.Collections.IDictionary]) {
+                $b = [int]$data.Version.Build
+                $this.Version = if ($b -ge 0) {
+                    [version]"$($data.Version.Major).$($data.Version.Minor).$b"
+                } else {
+                    [version]"$($data.Version.Major).$($data.Version.Minor)"
+                }
+            } else {
+                $this.Version = [version]$data.Version
+            }
+        }
         $this.Author = $data.Author
         $this.DefaultEffect = $data.DefaultEffect
         $this.Rules = $data.Rules | ForEach-Object { [Rule]::new($_) }

--- a/Gatekeeper/Classes/Property.ps1
+++ b/Gatekeeper/Classes/Property.ps1
@@ -1,28 +1,27 @@
 . $PSScriptRoot\..\Public\ConvertFrom-JsonToHashtable.ps1
 
 class PropertyValidation {
-    [int]$Minimum
-    [int]$Maximum
-    [int]$MinLength
-    [int]$MaxLength
+    [Nullable[int]]$Minimum
+    [Nullable[int]]$Maximum
+    [Nullable[int]]$MinLength
+    [Nullable[int]]$MaxLength
     [string]$Pattern
 
     PropertyValidation([hashtable]$data) {
-        if ($data.ContainsKey("Minimum")) { $this.Minimum = [int]$data.Minimum }
-        if ($data.ContainsKey("Maximum")) { $this.Maximum = [int]$data.Maximum }
-        if ($data.ContainsKey("MinLength")) { $this.MinLength = [int]$data.MinLength }
-        if ($data.ContainsKey("MaxLength")) { $this.MaxLength = [int]$data.MaxLength }
+        if ($data.ContainsKey("Minimum") -and $null -ne $data.Minimum) { $this.Minimum = [int]$data.Minimum }
+        if ($data.ContainsKey("Maximum") -and $null -ne $data.Maximum) { $this.Maximum = [int]$data.Maximum }
+        if ($data.ContainsKey("MinLength") -and $null -ne $data.MinLength) { $this.MinLength = [int]$data.MinLength }
+        if ($data.ContainsKey("MaxLength") -and $null -ne $data.MaxLength) { $this.MaxLength = [int]$data.MaxLength }
         if ($data.ContainsKey("Pattern")) { $this.Pattern = $data.Pattern }
     }
 
     [hashtable] ToHashtable() {
-        $data = @{
-            Minimum = $this.Minimum
-            Maximum = $this.Maximum
-            MinLength = $this.MinLength
-            MaxLength = $this.MaxLength
-            Pattern = $this.Pattern
-        }
+        $data = @{}
+        if ($null -ne $this.Minimum) { $data.Minimum = $this.Minimum }
+        if ($null -ne $this.Maximum) { $data.Maximum = $this.Maximum }
+        if ($null -ne $this.MinLength) { $data.MinLength = $this.MinLength }
+        if ($null -ne $this.MaxLength) { $data.MaxLength = $this.MaxLength }
+        if ($this.Pattern) { $data.Pattern = $this.Pattern }
         return $data
     }
 }

--- a/tests/Classes.tests.ps1
+++ b/tests/Classes.tests.ps1
@@ -1,0 +1,375 @@
+BeforeDiscovery {
+    if ($env:BHPSModuleManifest -eq $null -or $env:BHProjectPath -eq $null -or $env:BHProjectName -eq $null) {
+        . $PSScriptRoot\..\build.ps1 -Task Build
+    }
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'Output'
+    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+    $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+    $outputModVerManifest = Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1"
+    Get-Module $env:BHProjectName | Remove-Module -Force -ErrorAction Ignore
+    Import-Module -Name $outputModVerManifest -Verbose:$false -ErrorAction Stop
+}
+
+Describe 'ConditionGroup' {
+    Describe 'constructor - mutual exclusion' {
+        It 'Throws when AllOf and AnyOf are both specified' {
+            {
+                [ConditionGroup]::new(@{
+                    AllOf = @(@{ Property = 'A'; Operator = 'Equals'; Value = 'B' })
+                    AnyOf = @(@{ Property = 'A'; Operator = 'Equals'; Value = 'B' })
+                })
+            } | Should -Throw -ExpectedMessage '*AllOf, AnyOf, Not*'
+        }
+
+        It 'Throws when AllOf and Not are both specified' {
+            {
+                [ConditionGroup]::new(@{
+                    AllOf = @(@{ Property = 'A'; Operator = 'Equals'; Value = 'B' })
+                    Not   = @(@{ Property = 'A'; Operator = 'Equals'; Value = 'B' })
+                })
+            } | Should -Throw -ExpectedMessage '*AllOf, AnyOf, Not*'
+        }
+
+        It 'Throws when AnyOf and Not are both specified' {
+            {
+                [ConditionGroup]::new(@{
+                    AnyOf = @(@{ Property = 'A'; Operator = 'Equals'; Value = 'B' })
+                    Not   = @(@{ Property = 'A'; Operator = 'Equals'; Value = 'B' })
+                })
+            } | Should -Throw -ExpectedMessage '*AllOf, AnyOf, Not*'
+        }
+
+        It 'Throws when Property is present without Operator and Value' {
+            {
+                [ConditionGroup]::new(@{ Property = 'Environment' })
+            } | Should -Throw -ExpectedMessage '*Operator and Value*'
+        }
+
+        It 'Throws when Property is present without Value' {
+            {
+                [ConditionGroup]::new(@{ Property = 'Environment'; Operator = 'Equals' })
+            } | Should -Throw -ExpectedMessage '*Operator and Value*'
+        }
+
+        It 'Throws when AllOf is combined with flat Property/Operator/Value fields' {
+            {
+                [ConditionGroup]::new(@{
+                    AllOf    = @(@{ Property = 'A'; Operator = 'Equals'; Value = 'B' })
+                    Property = 'Environment'
+                    Operator = 'Equals'
+                    Value    = 'Staging'
+                })
+            } | Should -Throw -ExpectedMessage '*Property, Operator, and Value*'
+        }
+    }
+
+    Describe 'IsValid' {
+        It 'Returns $true for a flat leaf condition' {
+            $cg = [ConditionGroup]::new(@{
+                Property = 'Environment'
+                Operator = 'Equals'
+                Value    = 'Production'
+            })
+            $cg.IsValid() | Should -BeTrue
+        }
+
+        It 'Returns $false when Value is cleared after construction' {
+            $cg = [ConditionGroup]::new(@{
+                Property = 'Environment'
+                Operator = 'Equals'
+                Value    = 'Production'
+            })
+            $cg.Value = $null
+            $cg.IsValid() | Should -BeFalse
+        }
+    }
+
+    Describe 'ToString' {
+        It 'Returns flat condition string' {
+            $cg = [ConditionGroup]::new(@{
+                Property = 'Environment'
+                Operator = 'Equals'
+                Value    = 'Staging'
+            })
+            $cg.ToString() | Should -Be 'Environment Equals Staging'
+        }
+
+        It 'Returns AllOf string' {
+            $cg = [ConditionGroup]::new(@{
+                AllOf = @(
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Staging' },
+                    @{ Property = 'IsCompliant'; Operator = 'Equals'; Value = 'true' }
+                )
+            })
+            $cg.ToString() | Should -Be 'AllOf(Environment Equals Staging, IsCompliant Equals true)'
+        }
+
+        It 'Returns AnyOf string' {
+            $cg = [ConditionGroup]::new(@{
+                AnyOf = @(
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Staging' },
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' }
+                )
+            })
+            $cg.ToString() | Should -Be 'AnyOf(Environment Equals Staging, Environment Equals Production)'
+        }
+
+        It 'Returns Not string' {
+            $cg = [ConditionGroup]::new(@{
+                Not = @(
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' }
+                )
+            })
+            $cg.ToString() | Should -Be 'Not(Environment Equals Production)'
+        }
+
+        It 'Returns nested AllOf+AnyOf string' {
+            $cg = [ConditionGroup]::new(@{
+                AllOf = @(
+                    @{
+                        AnyOf = @(
+                            @{ Property = 'IsCompliant'; Operator = 'Equals'; Value = 'true' },
+                            @{ Property = 'Percentage'; Operator = 'LessThan'; Value = '11' }
+                        )
+                    },
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Staging' }
+                )
+            })
+            $cg.ToString() | Should -Be 'AllOf(AnyOf(IsCompliant Equals true, Percentage LessThan 11), Environment Equals Staging)'
+        }
+    }
+}
+
+Describe 'ConditionGroupTransformAttribute' {
+    BeforeAll {
+        $script:propertySet = Read-PropertySet -File "$PSScriptRoot\fixtures\Properties.json"
+        $script:context = @{
+            Percentage  = 30
+            Environment = 'Production'
+            IsCompliant = $true
+        }
+    }
+
+    It 'Converts a hashtable to ConditionGroup via Test-Condition' {
+        $ht = @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' }
+        { Test-Condition -Condition $ht -PropertySet $script:propertySet -Context $script:context } |
+            Should -Not -Throw
+        Test-Condition -Condition $ht -PropertySet $script:propertySet -Context $script:context |
+            Should -BeTrue
+    }
+
+    It 'Passes through an existing ConditionGroup via Test-Condition' {
+        $cg = [ConditionGroup]::new(@{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' })
+        Test-Condition -Condition $cg -PropertySet $script:propertySet -Context $script:context |
+            Should -BeTrue
+    }
+
+    It 'Converts a JSON file path string to ConditionGroup via Test-Condition' {
+        $conditionPath = Join-Path $TestDrive 'Condition.json'
+        @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' } |
+            ConvertTo-Json | Set-Content -Path $conditionPath
+        Test-Condition -Condition $conditionPath -PropertySet $script:propertySet -Context $script:context |
+            Should -BeTrue
+    }
+
+    It 'Throws a useful message for unsupported input type' {
+        {
+            Test-Condition -Condition 42 -PropertySet $script:propertySet -Context $script:context
+        } | Should -Throw -ExpectedMessage '*Cannot convert type*'
+    }
+}
+
+Describe 'PropertyDefinition.Validate' {
+    It 'Returns $true when no validation is configured' {
+        $pd = [PropertyDefinition]::new('Env', @{ Type = 'string' })
+        $pd.Validate('anything') | Should -BeTrue
+    }
+
+    It 'Returns $true for a valid integer within range' {
+        $pd = [PropertyDefinition]::new('Count', @{
+            Type       = 'integer'
+            Validation = @{ Minimum = 0; Maximum = 100 }
+        })
+        $pd.Validate(50) | Should -BeTrue
+    }
+
+    It 'Returns $false and emits warning when integer is below minimum' {
+        $pd = [PropertyDefinition]::new('Count', @{
+            Type       = 'integer'
+            Validation = @{ Minimum = 10; Maximum = 100 }
+        })
+        $warnings = & { $pd.Validate(5) } 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+        $warnings | Should -Not -BeNullOrEmpty
+        $pd.Validate(5) | Should -BeFalse
+    }
+
+    It 'Returns $false when integer exceeds maximum' {
+        $pd = [PropertyDefinition]::new('Count', @{
+            Type       = 'integer'
+            Validation = @{ Minimum = 0; Maximum = 10 }
+        })
+        $pd.Validate(50) | Should -BeFalse
+    }
+
+    It 'Returns $false when string is below MinLength' {
+        $pd = [PropertyDefinition]::new('Code', @{
+            Type       = 'string'
+            Validation = @{ MinLength = 5; MaxLength = 20 }
+        })
+        $pd.Validate('abc') | Should -BeFalse
+    }
+
+    It 'Returns $false when string exceeds MaxLength' {
+        $pd = [PropertyDefinition]::new('Code', @{
+            Type       = 'string'
+            Validation = @{ MinLength = 1; MaxLength = 5 }
+        })
+        $pd.Validate('toolongstring') | Should -BeFalse
+    }
+
+    It 'Returns $false when string does not match pattern' {
+        $pd = [PropertyDefinition]::new('ZipCode', @{
+            Type       = 'string'
+            Validation = @{ Pattern = '^\d{5}$' }
+        })
+        $pd.Validate('abc') | Should -BeFalse
+    }
+
+    It 'Returns $true when string matches pattern' {
+        $pd = [PropertyDefinition]::new('ZipCode', @{
+            Type       = 'string'
+            Validation = @{ Pattern = '^\d{5}$' }
+        })
+        $pd.Validate('12345') | Should -BeTrue
+    }
+}
+
+Describe 'PropertySet' {
+    Describe 'AddProperty' {
+        It 'Adds entry keyed by property Name' {
+            $ps = [PropertySet]::new('TestSet')
+            $pd = [PropertyDefinition]::new('Environment', @{ Type = 'string' })
+            $ps.AddProperty($pd)
+            $ps.Properties.ContainsKey('Environment') | Should -BeTrue
+        }
+
+        It 'Returns $this for method chaining' {
+            $ps = [PropertySet]::new('TestSet')
+            $pd = [PropertyDefinition]::new('Environment', @{ Type = 'string' })
+            $result = $ps.AddProperty($pd)
+            $result | Should -Be $ps
+        }
+
+        It 'Supports chaining multiple AddProperty calls' {
+            $ps = [PropertySet]::new('TestSet')
+            $ps.AddProperty([PropertyDefinition]::new('Env', @{ Type = 'string' })).AddProperty(
+                [PropertyDefinition]::new('Score', @{ Type = 'integer' })
+            ) | Out-Null
+            $ps.Properties.Keys.Count | Should -Be 2
+        }
+    }
+
+    Describe 'GetProperty' {
+        It 'Returns the correct PropertyDefinition by name' {
+            $ps = [PropertySet]::new('TestSet')
+            $pd = [PropertyDefinition]::new('Environment', @{ Type = 'string' })
+            $ps.AddProperty($pd)
+            $result = $ps.GetProperty('Environment')
+            $result | Should -Be $pd
+            $result.Name | Should -Be 'Environment'
+        }
+    }
+
+    Describe 'ContainsKey' {
+        BeforeAll {
+            $script:ps = [PropertySet]::new('TestSet')
+            $script:ps.AddProperty([PropertyDefinition]::new('Environment', @{ Type = 'string' }))
+        }
+
+        It 'Returns $true for an existing property' {
+            $script:ps.ContainsKey('Environment') | Should -BeTrue
+        }
+
+        It 'Returns $false for a missing property' {
+            $script:ps.ContainsKey('Missing') | Should -BeFalse
+        }
+    }
+
+    Describe 'FromFile' {
+        It 'Sets Name from filename without extension' {
+            $ps = [PropertySet]::FromFile("$PSScriptRoot\fixtures\Properties.json")
+            $ps.Name | Should -Be 'Properties'
+        }
+
+        It 'Loads all top-level properties' {
+            $ps = [PropertySet]::FromFile("$PSScriptRoot\fixtures\Properties.json")
+            $ps.ContainsKey('Percentage') | Should -BeTrue
+            $ps.ContainsKey('Environment') | Should -BeTrue
+            $ps.ContainsKey('IsCompliant') | Should -BeTrue
+        }
+    }
+
+    Describe 'Save and FromFile round-trip' {
+        It 'Preserves properties and validation constraints' {
+            $original = [PropertySet]::new('RoundTrip')
+            $original.AddProperty([PropertyDefinition]::new('Score', @{
+                Type       = 'integer'
+                Validation = @{ Minimum = 5; Maximum = 100 }
+            }))
+            $original.AddProperty([PropertyDefinition]::new('Label', @{
+                Type = 'string'
+            }))
+
+            $savePath = Join-Path $TestDrive 'RoundTrip.json'
+            $original.FilePath = $savePath
+            $original.Save()
+
+            $loaded = [PropertySet]::FromFile($savePath)
+            $loaded.Name | Should -Be 'RoundTrip'
+            $loaded.ContainsKey('Score') | Should -BeTrue
+            $loaded.ContainsKey('Label') | Should -BeTrue
+            $loaded.GetProperty('Score').Type | Should -Be 'integer'
+            $loaded.GetProperty('Score').Validation.Minimum | Should -Be 5
+            $loaded.GetProperty('Score').Validation.Maximum | Should -Be 100
+            $loaded.GetProperty('Label').Type | Should -Be 'string'
+        }
+    }
+}
+
+Describe 'FeatureFlag' {
+    Describe 'FromJson' {
+        It 'Round-trips Name, DefaultEffect, and Rules count' {
+            $json = Get-Content -Raw -Path "$PSScriptRoot\fixtures\FeatureFlag.json"
+            $ff = [FeatureFlag]::FromJson($json)
+            $ff.Name | Should -Be 'New Startup Sound'
+            $ff.DefaultEffect | Should -Be 'Deny'
+            $ff.Rules | Should -HaveCount 3
+        }
+    }
+
+    Describe 'FromFile' {
+        It 'Loads Name, FilePath, and Rules from fixture' {
+            $ff = [FeatureFlag]::FromFile("$PSScriptRoot\fixtures\FeatureFlag.json")
+            $ff.Name | Should -Be 'New Startup Sound'
+            $ff.FilePath | Should -Not -BeNullOrEmpty
+            $ff.Rules | Should -HaveCount 3
+        }
+    }
+
+    Describe 'Save' {
+        It 'Writes JSON that re-parses to an equivalent object' {
+            $original = [FeatureFlag]::FromFile("$PSScriptRoot\fixtures\FeatureFlag.json")
+            $savePath = Join-Path $TestDrive 'SavedFlag.json'
+            $original.FilePath = $savePath
+            $original.Save()
+
+            $loaded = [FeatureFlag]::FromFile($savePath)
+            $loaded.Name | Should -Be $original.Name
+            $loaded.DefaultEffect | Should -Be $original.DefaultEffect
+            $loaded.Rules | Should -HaveCount $original.Rules.Count
+            $loaded.Author | Should -Be $original.Author
+            $loaded.Description | Should -Be $original.Description
+        }
+    }
+}


### PR DESCRIPTION
Fixes #24.

Adds `tests/Classes.tests.ps1` with contract tests for `ConditionGroup`, `ConditionGroupTransformAttribute`, `PropertyDefinition.Validate`, `PropertySet`, and `FeatureFlag`.

Also fixes four bugs exposed by the new tests:

- **PropertyValidation**: Use `[Nullable[int]]` for integer constraint fields so unset constraints (`MinLength`, `MaxLength`, etc.) are not incorrectly applied during validation.
- **PropertyValidation.ToHashtable**: Omit null/unset fields so saved JSON passes schema validation on a Save -> FromFile round-trip.
- **ConditionGroup constructor**: Treat keys present with null values as absent (handles `ConvertTo-Json` round-trips that serialize all class fields). Use `Property` presence (not `Operator`) as the canonical signal for a flat/leaf condition — `Operator`'s enum default is always serialized as a non-null string, making it unreliable as a discriminator.
- **FeatureFlag constructor**: Handle `Version` deserialized as a dictionary from a `ConvertTo-Json` round-trip rather than a version string.

## Test coverage added

- ConditionGroup constructor: mutual exclusion of AllOf/AnyOf/Not; Property without Operator/Value; group+flat mix
- ConditionGroup.IsValid: flat leaf returns true; cleared Value returns false
- ConditionGroup.ToString: flat, AllOf, AnyOf, Not, nested
- ConditionGroupTransformAttribute: hashtable, passthrough, file path, unsupported type (all via Test-Condition)
- PropertyDefinition.Validate: all constraint violations + pass cases
- PropertySet: AddProperty keying/chaining, GetProperty, ContainsKey, FromFile name, Save/FromFile round-trip
- FeatureFlag: FromJson, FromFile, Save round-trip