### PR TITLE
test(coverage): add tests for unexercised public functions

### DIFF
--- a/Gatekeeper/Classes/FeatureFlag.ps1
+++ b/Gatekeeper/Classes/FeatureFlag.ps1
@@ -205,7 +205,14 @@ class FeatureFlag {
             throw "No file path specified to save FeatureFlag."
         }
         Write-Verbose "Saving FeatureFlag to file: $($this.FilePath)"
-        $json = $this | ConvertTo-Json -Depth 10 -EnumsAsStrings
+        $jsonParams = @{ Depth = 10 }
+        # -EnumsAsStrings was introduced in PowerShell 7.2; on older hosts
+        # (e.g. Windows PowerShell 5.1) enums serialize as their integer value,
+        # which still round-trips back to the enum on load.
+        if ((Get-Command ConvertTo-Json).Parameters.ContainsKey('EnumsAsStrings')) {
+            $jsonParams['EnumsAsStrings'] = $true
+        }
+        $json = $this | ConvertTo-Json @jsonParams
         Set-Content -Path $this.FilePath -Value $json
     }
 }

--- a/Gatekeeper/Public/ConvertFrom-JsonToHashtable.ps1
+++ b/Gatekeeper/Public/ConvertFrom-JsonToHashtable.ps1
@@ -51,6 +51,7 @@ function ConvertTo-Hashtable {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
+        [AllowNull()]
         [object]$InputObject
     )
 

--- a/tests/ConvertFrom-JsonToHashtable.tests.ps1
+++ b/tests/ConvertFrom-JsonToHashtable.tests.ps1
@@ -1,0 +1,37 @@
+BeforeDiscovery {
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'Output'
+    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+    $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+    $outputModVerManifest = Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1"
+
+    Get-Module $env:BHProjectName -All | Remove-Module -Force -ErrorAction Ignore
+    Get-Module 'Configuration' -All | Remove-Module -Force -ErrorAction Ignore
+    Import-Module -Name $outputModVerManifest -Verbose:$false -ErrorAction Stop
+}
+
+Describe 'ConvertFrom-JsonToHashtable' {
+    It 'converts a JSON object to a hashtable with correct keys' {
+        $result = ConvertFrom-JsonToHashtable -InputObject '{"key":"value","count":42}'
+        $result | Should -BeOfType [hashtable]
+        $result['key'] | Should -Be 'value'
+        $result['count'] | Should -Be 42
+    }
+
+    It 'converts nested JSON objects to nested hashtables' {
+        $result = ConvertFrom-JsonToHashtable -InputObject '{"outer":{"inner":"data"}}'
+        $result['outer'] | Should -BeOfType [hashtable]
+        $result['outer']['inner'] | Should -Be 'data'
+    }
+
+    It 'converts a JSON array to an array' {
+        $result = ConvertFrom-JsonToHashtable -InputObject '[1,2,3]'
+        $result | Should -HaveCount 3
+        $result[0] | Should -Be 1
+        $result[2] | Should -Be 3
+    }
+
+    It 'throws on invalid JSON' {
+        { ConvertFrom-JsonToHashtable -InputObject 'not valid json {{{' } | Should -Throw
+    }
+}

--- a/tests/Fixtures.tests.ps1
+++ b/tests/Fixtures.tests.ps1
@@ -8,11 +8,9 @@ Describe '<_.name>' -ForEach $script:fixtures {
         $json = Get-Content -Path $_.FullName -Raw | ConvertFrom-Json
         $script:schema = $json.'$schema'
 
-        $resolvePathSplat = @{
-            RelativeBasePath = $_.Directory.FullName
-            Path = $script:schema
-        }
-        $script:schemaFilePath = Resolve-Path @resolvePathSplat
+        # Resolve-Path -RelativeBasePath was added in PowerShell 7.4, so join the
+        # fixture's directory with the (relative) $schema path before resolving.
+        $script:schemaFilePath = Resolve-Path -Path (Join-Path -Path $_.Directory.FullName -ChildPath $script:schema)
     }
     It 'Has a schema' {
         $script:schema | Should -Not -BeNullOrEmpty

--- a/tests/Import-GatekeeperConfig.tests.ps1
+++ b/tests/Import-GatekeeperConfig.tests.ps1
@@ -1,0 +1,171 @@
+BeforeDiscovery {
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'Output'
+    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+    $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+    $outputModVerManifest = Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1"
+
+    Get-Module $env:BHProjectName -All | Remove-Module -Force -ErrorAction Ignore
+    Get-Module 'Configuration' -All | Remove-Module -Force -ErrorAction Ignore
+    Import-Module -Name $outputModVerManifest -Verbose:$false -ErrorAction Stop
+}
+
+Describe 'Import-GatekeeperConfig' {
+    BeforeAll {
+        $script:minConfig = @{
+            Version   = '0.1.0'
+            FilePaths = @{ Schemas = '' }
+            Security  = @{ AllowUncPaths = $false }
+            Logging   = @{}
+        }
+    }
+
+    AfterAll {
+        # Restore real configuration so later test files see clean state
+        Import-GatekeeperConfig -ForceReload
+    }
+
+    It 'returns a hashtable on cold load' {
+        $result = Import-GatekeeperConfig -ForceReload
+        $result | Should -Not -BeNullOrEmpty
+        $result | Should -BeOfType [hashtable]
+    }
+
+    It 'uses cached config on second call without -ForceReload' {
+        Mock -CommandName 'Import-Configuration' -ModuleName $env:BHProjectName { $script:minConfig }
+        Import-GatekeeperConfig
+        Should -Invoke 'Import-Configuration' -ModuleName $env:BHProjectName -Times 0
+    }
+
+    It '-ForceReload bypasses cache and calls Import-Configuration' {
+        Mock -CommandName 'Import-Configuration' -ModuleName $env:BHProjectName { $script:minConfig }
+        Import-GatekeeperConfig -ForceReload
+        Should -Invoke 'Import-Configuration' -ModuleName $env:BHProjectName -Times 1
+    }
+
+    Context 'Logging configuration parsing' {
+        BeforeAll {
+            $testConfig = @{
+                Version   = '0.1.0'
+                FilePaths = @{ Schemas = '' }
+                Security  = @{ AllowUncPaths = $false }
+                Logging   = @{
+                    Allow = @{ Enabled = $true; Script = { param($Rule) Write-Host 'allow' } }
+                    Deny  = @{ Enabled = $true; Script = 'param($Rule); Write-Host "deny"' }
+                    Audit = @{ Enabled = $false; Script = 'param($Rule); Write-Host "audit"' }
+                }
+            }
+            Mock -CommandName 'Import-Configuration' -ModuleName $env:BHProjectName { $testConfig }
+            Import-GatekeeperConfig -ForceReload
+        }
+
+        It 'parses an inline scriptblock for enabled logging level' {
+            InModuleScope $env:BHProjectName {
+                $script:GatekeeperLogging['Allow'] | Should -Not -BeNullOrEmpty
+                $script:GatekeeperLogging['Allow'] | Should -BeOfType [scriptblock]
+            }
+        }
+
+        It 'compiles a string script into a scriptblock for enabled logging level' {
+            InModuleScope $env:BHProjectName {
+                $script:GatekeeperLogging['Deny'] | Should -Not -BeNullOrEmpty
+                $script:GatekeeperLogging['Deny'] | Should -BeOfType [scriptblock]
+            }
+        }
+
+        It 'does not store disabled logging levels in GatekeeperLogging' {
+            InModuleScope $env:BHProjectName {
+                $script:GatekeeperLogging.ContainsKey('Audit') | Should -BeFalse
+            }
+        }
+    }
+}
+
+Describe 'Get-FeatureFlagFolder' {
+    BeforeAll {
+        $script:ffFolder = Join-Path (Get-PSDrive TestDrive).Root 'FeatureFlags'
+        New-Item -Path $script:ffFolder -ItemType Directory -Force | Out-Null
+    }
+
+    AfterEach {
+        # Reset module config so each test starts clean
+        InModuleScope $env:BHProjectName -Parameters @{ Folder = $script:ffFolder } {
+            param($Folder)
+            $script:GatekeeperConfiguration = @{
+                FilePaths = @{ FeatureFlags = $Folder }
+            }
+        }
+    }
+
+    It 'returns the configured folder path' {
+        InModuleScope $env:BHProjectName -Parameters @{ Folder = $script:ffFolder } {
+            param($Folder)
+            $script:GatekeeperConfiguration = @{
+                FilePaths = @{ FeatureFlags = $Folder }
+            }
+        }
+        $result = Get-FeatureFlagFolder
+        $result | Should -Not -BeNullOrEmpty
+        $result | Should -Be $script:ffFolder
+    }
+
+    It 'creates the folder and persists path on first run' {
+        $script:firstRunRoot = Join-Path (Get-PSDrive TestDrive).Root 'FFFirstRunRoot'
+        InModuleScope $env:BHProjectName {
+            $script:GatekeeperConfiguration = @{ FilePaths = @{} }
+        }
+        Mock -CommandName 'Get-ConfigurationPath' -ModuleName $env:BHProjectName {
+            $script:firstRunRoot
+        }
+        Mock -CommandName 'Export-GatekeeperConfig' -ModuleName $env:BHProjectName {}
+
+        $result = Get-FeatureFlagFolder
+        $result | Should -Not -BeNullOrEmpty
+        Test-Path $result | Should -BeTrue
+        Should -Invoke 'Export-GatekeeperConfig' -ModuleName $env:BHProjectName -Times 1
+    }
+}
+
+Describe 'Get-PropertySetFolder' {
+    BeforeAll {
+        $script:psFolder = Join-Path (Get-PSDrive TestDrive).Root 'PropertySet'
+        New-Item -Path $script:psFolder -ItemType Directory -Force | Out-Null
+    }
+
+    AfterEach {
+        InModuleScope $env:BHProjectName -Parameters @{ Folder = $script:psFolder } {
+            param($Folder)
+            $script:GatekeeperConfiguration = @{
+                FilePaths = @{ PropertySet = $Folder }
+            }
+        }
+    }
+
+    It 'returns the configured folder path' {
+        InModuleScope $env:BHProjectName -Parameters @{ Folder = $script:psFolder } {
+            param($Folder)
+            $script:GatekeeperConfiguration = @{
+                FilePaths = @{ PropertySet = $Folder }
+            }
+        }
+        $result = Get-PropertySetFolder
+        $result | Should -Not -BeNullOrEmpty
+        $result | Should -Be $script:psFolder
+    }
+
+    It 'creates the folder and persists path on first run' {
+        $script:psFirstRunRoot = Join-Path (Get-PSDrive TestDrive).Root 'PSFirstRunRoot'
+        InModuleScope $env:BHProjectName {
+            $script:GatekeeperConfiguration = @{ FilePaths = @{} }
+        }
+        Mock -CommandName 'Get-ConfigurationPath' -ModuleName $env:BHProjectName {
+            $script:psFirstRunRoot
+        }
+        Mock -CommandName 'Export-GatekeeperConfig' -ModuleName $env:BHProjectName {}
+
+        $result = Get-PropertySetFolder
+        $result | Should -Not -BeNullOrEmpty
+        Test-Path $result | Should -BeTrue
+        Should -Invoke 'Export-GatekeeperConfig' -ModuleName $env:BHProjectName -Times 1
+    }
+}

--- a/tests/NewFiles.tests.ps1
+++ b/tests/NewFiles.tests.ps1
@@ -80,5 +80,74 @@ Describe 'File Creations' {
             $filePath = $script:featureFlag.FilePath
             Test-Path $filePath | Should -BeTrue
         }
+
+        It 'round-trips: saved feature flag can be read back with correct values' {
+            $filePath = $script:featureFlag.FilePath
+            $loaded = Read-FeatureFlag -FilePath $filePath
+            $loaded | Should -BeOfType FeatureFlag
+            $loaded.Name | Should -Be $script:featureFlag.Name
+            $loaded.DefaultEffect | Should -Be $script:featureFlag.DefaultEffect
+        }
+    }
+
+    Context 'New-Property' {
+        It 'returns a PropertyDefinition object' {
+            $result = New-Property -Name 'TestProp' -Type 'string'
+            $result | Should -BeOfType PropertyDefinition
+        }
+
+        It 'populates Name and Type fields' {
+            $result = New-Property -Name 'Count' -Type 'integer'
+            $result.Name | Should -Be 'Count'
+            $result.Type | Should -Be 'integer'
+        }
+
+        It 'populates Validation when provided' {
+            $result = New-Property -Name 'Score' -Type 'integer' -Validation @{ Minimum = 0; Maximum = 100 }
+            $result.Validation | Should -Not -BeNullOrEmpty
+            $result.Validation.Minimum | Should -Be 0
+            $result.Validation.Maximum | Should -Be 100
+        }
+
+        It 'populates Enum values when provided' {
+            $result = New-Property -Name 'Env' -Type 'string' -EnumValues @('Prod', 'Staging', 'Dev')
+            $result.Enum | Should -HaveCount 3
+            $result.Enum | Should -Contain 'Prod'
+        }
+    }
+
+    Context 'New-PropertySet' {
+        It 'returns a PropertySet object' {
+            $result = New-PropertySet -Name 'TestSet'
+            $result | Should -BeOfType PropertySet
+        }
+
+        It 'includes piped properties in the set' {
+            $p1 = New-Property -Name 'Host' -Type 'string'
+            $p2 = New-Property -Name 'Port' -Type 'integer'
+            $result = $p1, $p2 | New-PropertySet -Name 'Network'
+            $result.Properties.ContainsKey('Host') | Should -BeTrue
+            $result.Properties.ContainsKey('Port') | Should -BeTrue
+        }
+    }
+
+    Context 'Save-PropertySet' {
+        BeforeAll {
+            $p = New-Property -Name 'Region' -Type 'string'
+            $script:savedSet = $p | New-PropertySet -Name 'SaveTest'
+            $script:savedPath = Join-Path (Get-PSDrive TestDrive).Root 'PropertySet' 'SaveTest.json'
+        }
+
+        It 'creates the file at the expected path' {
+            Save-PropertySet -PropertySet $script:savedSet -FilePath $script:savedPath
+            Test-Path $script:savedPath | Should -BeTrue
+        }
+
+        It 'round-trips: saved PropertySet can be read back with correct properties' {
+            $loaded = Read-PropertySet -FilePath $script:savedPath
+            $loaded | Should -BeOfType PropertySet
+            $loaded.Properties.ContainsKey('Region') | Should -BeTrue
+            $loaded.Properties['Region'].Type | Should -Be 'string'
+        }
     }
 }

--- a/tests/NewFiles.tests.ps1
+++ b/tests/NewFiles.tests.ps1
@@ -135,7 +135,7 @@ Describe 'File Creations' {
         BeforeAll {
             $p = New-Property -Name 'Region' -Type 'string'
             $script:savedSet = $p | New-PropertySet -Name 'SaveTest'
-            $script:savedPath = Join-Path (Get-PSDrive TestDrive).Root 'PropertySet' 'SaveTest.json'
+            $script:savedPath = Join-Path -Path (Join-Path -Path (Get-PSDrive TestDrive).Root -ChildPath 'PropertySet') -ChildPath 'SaveTest.json'
         }
 
         It 'creates the file at the expected path' {

--- a/tests/Read-PropertySet.tests.ps1
+++ b/tests/Read-PropertySet.tests.ps1
@@ -20,4 +20,31 @@ Describe 'Read-PropertySet' {
     It 'Returns a PropertySet object' {
         $script:actual | Should -BeOfType 'PropertySet'
     }
+
+    It 'contains all expected property keys from the fixture' {
+        $script:actual.Properties.ContainsKey('Percentage') | Should -BeTrue
+        $script:actual.Properties.ContainsKey('Environment') | Should -BeTrue
+        $script:actual.Properties.ContainsKey('IsCompliant') | Should -BeTrue
+    }
+
+    It 'loads property types correctly' {
+        $script:actual.Properties['Percentage'].Type | Should -Be 'integer'
+        $script:actual.Properties['Environment'].Type | Should -Be 'string'
+        $script:actual.Properties['IsCompliant'].Type | Should -Be 'boolean'
+    }
+
+    It 'loads validation constraints for integer properties' {
+        $validation = $script:actual.Properties['Percentage'].Validation
+        $validation | Should -Not -BeNullOrEmpty
+        $validation.Minimum | Should -Be 0
+        $validation.Maximum | Should -Be 99
+    }
+
+    It 'loads enum values for string properties' {
+        $enum = $script:actual.Properties['Environment'].Enum
+        $enum | Should -Not -BeNullOrEmpty
+        $enum | Should -Contain 'Production'
+        $enum | Should -Contain 'Staging'
+        $enum | Should -Contain 'Dev'
+    }
 }


### PR DESCRIPTION
Fixes #25.

## Summary

- **New files**: `ConvertFrom-JsonToHashtable.tests.ps1`, `Import-GatekeeperConfig.tests.ps1`
- **Extended**: `NewFiles.tests.ps1`, `Read-PropertySet.tests.ps1`

### New coverage

| Function | Tests added |
|---|---|
| `ConvertFrom-JsonToHashtable` | object to hashtable, nested objects, array, invalid JSON throws |
| `Import-GatekeeperConfig` | cold load returns hashtable, caching (no re-read), `-ForceReload` calls `Import-Configuration`, inline scriptblock logging, string-to-scriptblock logging, disabled levels excluded from GatekeeperLogging |
| `Get-FeatureFlagFolder` | populated config returns path, first-run creates folder and persists via `Export-GatekeeperConfig` |
| `Get-PropertySetFolder` | same two cases as above |
| `New-Property` | correct type, Name/Type populated, Validation populated, Enum populated |
| `New-PropertySet` | correct type, piped properties added |
| `Save-PropertySet` | file created at path, round-trip via `Read-PropertySet` |

### Deepened existing tests

- `NewFiles.tests.ps1 Save-FeatureFlag`: added round-trip assertion (reads file back, checks Name and DefaultEffect)
- `Read-PropertySet.tests.ps1`: added property key presence, type correctness, validation constraints (Minimum/Maximum), and Enum values loaded from fixture

## Windows PowerShell 5.1 compatibility fixes

The new/deepened coverage surfaced several PS 5.1-only failures, fixed here:

| File | Problem | Fix |
|---|---|---|
| `Gatekeeper/Classes/FeatureFlag.ps1` | `ConvertTo-Json -EnumsAsStrings` — switch added in PS 7.2 | Only pass `-EnumsAsStrings` when the cmdlet supports it; on 5.1 enums serialize as their integer value, which still round-trips back to the enum on load |
| `Gatekeeper/Public/ConvertFrom-JsonToHashtable.ps1` | `ConvertTo-Hashtable` rejected `$null` property values (mandatory `[object]` param) — hit once `Save()` worked on 5.1, since round-tripped JSON contains `"AllOf": null` etc. | Added `[AllowNull()]` to the parameter |
| `tests/Fixtures.tests.ps1` | `Resolve-Path -RelativeBasePath` — parameter added in PS 7.4 | `Resolve-Path` of a `Join-Path`'d path |
| `tests/NewFiles.tests.ps1` | 3-argument `Join-Path X Y Z` — only PS 6+ | Nested two-argument `Join-Path` |

Full Pester suite: Windows PowerShell 5.1 — 367 passed / 0 failed / 8 skipped; PowerShell 7.6 — 370 passed / 0 failed / 5 skipped. (The extra 5.1 skips are the `Test-Json` fixture-schema tests, already gated on `PSVersion -ge 7`.)