### PR TITLE
test(architecture): add guardrail tests for structural invariants

### DIFF
--- a/Gatekeeper/Classes/FeatureFlag.ps1
+++ b/Gatekeeper/Classes/FeatureFlag.ps1
@@ -1,5 +1,4 @@
 . $PSScriptRoot\..\Enums\Effect.ps1
-. $PSScriptRoot\..\Public\ConvertFrom-JsonToHashtable.ps1
 
 enum Operator {
     Equals

--- a/Gatekeeper/Classes/Property.ps1
+++ b/Gatekeeper/Classes/Property.ps1
@@ -1,5 +1,3 @@
-. $PSScriptRoot\..\Public\ConvertFrom-JsonToHashtable.ps1
-
 class PropertyValidation {
     [int]$Minimum
     [int]$Maximum

--- a/Gatekeeper/Gatekeeper.psd1
+++ b/Gatekeeper/Gatekeeper.psd1
@@ -62,7 +62,7 @@
     # RequiredAssemblies = @()
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-    ScriptsToProcess = @('Enums\Effect.ps1', 'Classes\Property.ps1', 'Classes\FeatureFlag.ps1')
+    ScriptsToProcess = @('Enums\Effect.ps1', 'Public\ConvertFrom-JsonToHashtable.ps1', 'Classes\Property.ps1', 'Classes\FeatureFlag.ps1')
 
     # Type files (.ps1xml) to be loaded when importing this module
     # TypesToProcess = @()
@@ -74,7 +74,27 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = '*'
+    FunctionsToExport = @(
+        'ConvertFrom-JsonToHashtable',
+        'Export-GatekeeperConfig',
+        'Get-DefaultContext',
+        'Get-FeatureFlagFolder',
+        'Get-PropertySet',
+        'Get-PropertySetFolder',
+        'Import-GatekeeperConfig',
+        'New-Condition',
+        'New-ConditionGroup',
+        'New-FeatureFlag',
+        'New-Property',
+        'New-PropertySet',
+        'New-Rule',
+        'Read-FeatureFlag',
+        'Read-PropertySet',
+        'Save-FeatureFlag',
+        'Save-PropertySet',
+        'Test-Condition',
+        'Test-FeatureFlag'
+    )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport = '*'

--- a/tests/Architecture.tests.ps1
+++ b/tests/Architecture.tests.ps1
@@ -1,0 +1,55 @@
+BeforeAll {
+    $modulePath = Join-Path -Path $env:BHProjectPath -ChildPath $env:BHProjectName
+}
+
+Describe 'Architecture' {
+
+    Context 'No circular dependencies' {
+        It 'No file under Classes/ dot-sources anything under Public/' {
+            $classFiles = Get-ChildItem (Join-Path $modulePath 'Classes') -Filter '*.ps1'
+            foreach ($file in $classFiles) {
+                $content = Get-Content $file.FullName -Raw
+                $content | Should -Not -Match '(?m)^(\.\s+[^\r\n]*\\Public\\)' `
+                    -Because "$($file.Name) must not depend on Public/"
+            }
+        }
+    }
+
+    Context 'Class pattern consistency' {
+        It 'Primary classes with new([hashtable]) also define static FromJson and FromFile' {
+            $classFiles = Get-ChildItem (Join-Path $modulePath 'Classes') -Filter '*.ps1'
+            foreach ($className in @('FeatureFlag', 'PropertySet')) {
+                $file = $classFiles |
+                    Where-Object { (Get-Content $_.FullName -Raw) -match "class $className\b" } |
+                    Select-Object -First 1
+                $content = Get-Content $file.FullName -Raw
+                $content | Should -Match 'static\s+\[.+\]\s+FromJson\s*\(\s*\[string\]' `
+                    -Because "$className must have a static FromJson([string]) method"
+                $content | Should -Match 'static\s+\[.+\]\s+FromFile\s*\(\s*\[string\]' `
+                    -Because "$className must have a static FromFile([string]) method"
+            }
+        }
+    }
+
+    Context 'Effect enum matches configuration' {
+        It 'Effect enum values match Configuration.psd1 Logging keys exactly' {
+            $enumFile    = Join-Path $modulePath 'Enums\Effect.ps1'
+            $enumValues  = (Get-Content $enumFile -Raw) -split '\r?\n' |
+                Where-Object { $_ -match '^\s+[A-Z]\w*\s*$' } |
+                ForEach-Object { $_.Trim() } |
+                Sort-Object
+
+            $configFile  = Join-Path $modulePath 'Configuration.psd1'
+            $configKeys  = (& ([scriptblock]::Create((Get-Content $configFile -Raw)))).Logging.Keys | Sort-Object
+
+            $enumValues | Should -Be $configKeys
+        }
+    }
+
+    Context 'Manifest pinned exports' {
+        It 'FunctionsToExport is not a wildcard' {
+            $manifest = Import-PowerShellDataFile (Join-Path $modulePath "$($env:BHProjectName).psd1")
+            $manifest.FunctionsToExport | Should -Not -Be '*'
+        }
+    }
+}


### PR DESCRIPTION
Fixes #26.

Adds `tests/Architecture.tests.ps1` with four structural guardrail tests:

1. **No circular dependencies** - asserts no file under `Classes/` dot-sources from `Public/`. Fixed the existing violation by adding `ConvertFrom-JsonToHashtable.ps1` to `ScriptsToProcess` (loaded before the class files), removing the ad-hoc dot-source lines from `Property.ps1` and `FeatureFlag.ps1`.

2. **Class pattern consistency** - asserts that primary file-loadable classes (`FeatureFlag`, `PropertySet`) each expose `static FromJson([string])` and `static FromFile([string])`.

3. **Effect enum matches config keys** - asserts that `Effect` enum values and `Configuration.psd1` `Logging` keys are identical (would have caught the Warn/Warning mismatch from #15).

4. **Manifest pinned exports** - asserts `FunctionsToExport` is not a wildcard. Fixed by enumerating all 19 public functions explicitly in the manifest.

All 267 tests pass.