### PR TITLE
fix(Test-Condition): capture Validate result to enforce fail-closed contract

### DIFF
--- a/Gatekeeper/Public/Test-Condition.ps1
+++ b/Gatekeeper/Public/Test-Condition.ps1
@@ -91,11 +91,8 @@ function Test-Condition {
     $validation = $meta.Validation
 
     $actual = Convert-ToTypedValue -Type $propType -Value $Context[$propName]
-    $testTypedValueSplat = @{
-        PropertyDefinition = $meta
-        Value = $actual
-    }
-    Test-TypedValue @testTypedValueSplat | Out-Null
+    $valid = $meta.Validate($actual)
+    if (-not $valid) { return $false }
 
     if (
         $operator -in @("In", "NotIn") -and

--- a/tests/Test-Condition.tests.ps1
+++ b/tests/Test-Condition.tests.ps1
@@ -311,6 +311,20 @@ Describe 'Test-Condition' {
             Test-Condition @script:testConditionSplat -Condition (Join-Path $TestDrive 'missing.json')
         } | Should -Throw -ExpectedMessage '*File not found:*'
     }
+    It 'Returns false when context value fails property validation' {
+        $condition = @{
+            Property = "Percentage"
+            Operator = "Equals"
+            Value = 100
+        }
+        $invalidContext = @{
+            Percentage = 100
+            Environment = 'Production'
+            IsCompliant = $true
+        }
+        Test-Condition -PropertySet $script:propertySet -Context $invalidContext -Condition $condition |
+            Should -BeFalse
+    }
     It 'Throws on context missing property' {
         $condition = @{
             Property = "Tier"


### PR DESCRIPTION
Fixes #27.

`Test-Condition` was calling `Test-TypedValue ... | Out-Null`, discarding the validation return value. A context value violating property constraints would fire a `Write-Warning` but evaluation would continue unchanged, breaking the module's fail-closed contract.

**Root cause**: `Test-TypedValue` with `WithPropertyDefinition` calls `$PropertyDefinition.Validate()` but discards the result and returns nothing. The fix calls `$meta.Validate($actual)` directly, which correctly returns a boolean.

**Change**: Replace `Test-TypedValue @testTypedValueSplat | Out-Null` with `$valid = $meta.Validate($actual); if (-not $valid) { return $false }`. Also removes the now-unused `$testTypedValueSplat` variable.

**Test added**: `Returns false when context value fails property validation` - sets `Percentage = 100` (exceeds Maximum: 99) and asserts `Test-Condition` returns `$false`.

All 264 tests pass.