### PR TITLE
fix(Convert-ToTypedValue): handle string boolean coercion correctly

### DIFF
--- a/Gatekeeper/Private/Convert-ToTypedValue.ps1
+++ b/Gatekeeper/Private/Convert-ToTypedValue.ps1
@@ -12,7 +12,15 @@ function Convert-ToTypedValue {
             return [int]$Value
         }
         "boolean" {
-            return $Value -as [bool]
+            if ($Value -is [bool]) { return $Value }
+            if ($Value -is [int])  { return [bool]$Value }
+            switch ($Value.ToString().ToLower()) {
+                'true'  { return $true }
+                'false' { return $false }
+                '1'     { return $true }
+                '0'     { return $false }
+                default { throw "Cannot convert '$Value' to boolean" }
+            }
         }
         "string" {
             return [string]$Value

--- a/tests/Convert-ToTypedValue.tests.ps1
+++ b/tests/Convert-ToTypedValue.tests.ps1
@@ -43,17 +43,42 @@ Describe 'Convert-ToTypedValue' {
     Context 'Boolean' {
         It 'can cast a $true' {
             InModuleScope $env:BHProjectName {
-                Convert-ToTypedValue -Type 'Boolean' -Value $True | Should -BeOfType 'Boolean'
+                Convert-ToTypedValue -Type 'Boolean' -Value $True | Should -Be $true
+            }
+        }
+        It 'can cast a $false' {
+            InModuleScope $env:BHProjectName {
+                Convert-ToTypedValue -Type 'Boolean' -Value $False | Should -Be $false
             }
         }
         It 'can cast a "true"' {
             InModuleScope $env:BHProjectName {
-                Convert-ToTypedValue -Type 'Boolean' -Value "true" | Should -BeOfType 'Boolean'
+                Convert-ToTypedValue -Type 'Boolean' -Value "true" | Should -Be $true
+            }
+        }
+        It 'can cast a "false"' {
+            InModuleScope $env:BHProjectName {
+                Convert-ToTypedValue -Type 'Boolean' -Value "false" | Should -Be $false
+            }
+        }
+        It 'can cast a 1 as True' {
+            InModuleScope $env:BHProjectName {
+                Convert-ToTypedValue -Type 'Boolean' -Value 1 | Should -Be $true
             }
         }
         It 'can cast a 0 as False' {
             InModuleScope $env:BHProjectName {
-                Convert-ToTypedValue -Type 'Boolean' -Value 0 | Should -BeOfType 'Boolean'
+                Convert-ToTypedValue -Type 'Boolean' -Value 0 | Should -Be $false
+            }
+        }
+        It 'can cast a "1" as True' {
+            InModuleScope $env:BHProjectName {
+                Convert-ToTypedValue -Type 'Boolean' -Value "1" | Should -Be $true
+            }
+        }
+        It 'can cast a "0" as False' {
+            InModuleScope $env:BHProjectName {
+                Convert-ToTypedValue -Type 'Boolean' -Value "0" | Should -Be $false
             }
         }
     }


### PR DESCRIPTION
Fixes #28.

## Summary

Replace the `-as [bool]` operator with explicit string parsing. PowerShell's `-as [bool]` treats any non-empty string as true, which incorrectly coerces the string "false" to $true. This breaks feature flag evaluation for boolean context properties sourced from JSON or environment data where booleans are represented as strings.

## Changes

The `Convert-ToTypedValue` function now:
- Returns boolean values directly without conversion
- Casts integers using PowerShell's built-in boolean conversion
- Explicitly parses string representations: 'true'/'false'/'1'/'0' (case-insensitive)
- Throws a descriptive error for invalid string values

## Tests

Added comprehensive boolean test coverage including:
- Both literal boolean values ($true and $false)
- String representations of both true and false
- Integer forms (1 and 0)
- String integer forms ("1" and "0")

All 268 tests pass, including the new cases that previously would have failed.