### PR TITLE
fix(PropertyValidation): use Nullable[int] for threshold fields

### DIFF
--- a/Gatekeeper/Classes/Property.ps1
+++ b/Gatekeeper/Classes/Property.ps1
@@ -1,10 +1,10 @@
 . $PSScriptRoot\..\Public\ConvertFrom-JsonToHashtable.ps1
 
 class PropertyValidation {
-    [int]$Minimum
-    [int]$Maximum
-    [int]$MinLength
-    [int]$MaxLength
+    [Nullable[int]]$Minimum
+    [Nullable[int]]$Maximum
+    [Nullable[int]]$MinLength
+    [Nullable[int]]$MaxLength
     [string]$Pattern
 
     PropertyValidation([hashtable]$data) {
@@ -16,13 +16,12 @@ class PropertyValidation {
     }
 
     [hashtable] ToHashtable() {
-        $data = @{
-            Minimum = $this.Minimum
-            Maximum = $this.Maximum
-            MinLength = $this.MinLength
-            MaxLength = $this.MaxLength
-            Pattern = $this.Pattern
-        }
+        $data = @{}
+        if ($null -ne $this.Minimum) { $data.Minimum = $this.Minimum }
+        if ($null -ne $this.Maximum) { $data.Maximum = $this.Maximum }
+        if ($null -ne $this.MinLength) { $data.MinLength = $this.MinLength }
+        if ($null -ne $this.MaxLength) { $data.MaxLength = $this.MaxLength }
+        if ($this.Pattern) { $data.Pattern = $this.Pattern }
         return $data
     }
 }


### PR DESCRIPTION
Fixes #29.

## Summary

`PropertyValidation` declared `[int]$Minimum`, `[int]$Maximum`, `[int]$MinLength`, and `[int]$MaxLength`. Since `[int]` defaults to `0`, there was no way to distinguish "not configured" from "configured as zero". The `$null -ne $this.Validation.Minimum` guard was always `$true`, silently enforcing a minimum of 0 on every integer property without a configured minimum.

## Changes

- Changed all four numeric threshold fields to `[Nullable[int]]` so unset fields remain `$null`.
- Updated `ToHashtable()` to only emit keys whose values are non-null, preventing null entries from leaking into serialized JSON.

## Tests

All 263 tests pass; PSScriptAnalyzer clean.