### PR TITLE
fix(ConditionGroup): IsValid() returns true for group conditions

### DIFF
--- a/Gatekeeper/Classes/FeatureFlag.ps1
+++ b/Gatekeeper/Classes/FeatureFlag.ps1
@@ -80,12 +80,8 @@ class ConditionGroup {
     }
 
     [boolean]IsValid() {
-        # This check if for the top level condition group
-        # For nested condition groups (AllOf, AnyOf, Not) the validity is not checked.
-        if ($null -ne $this.Property -and $null -ne $this.Operator -and $null -ne $this.Value) {
-            return $true
-        }
-        return $false
+        if ($null -ne $this.AllOf -or $null -ne $this.AnyOf -or $null -ne $this.Not) { return $true }
+        return $null -ne $this.Property -and $null -ne $this.Operator -and $null -ne $this.Value
     }
     [string]ToString() {
         $sb = [System.Text.StringBuilder]::new()

--- a/tests/Classes.tests.ps1
+++ b/tests/Classes.tests.ps1
@@ -83,6 +83,34 @@ Describe 'ConditionGroup' {
             $cg.Value = $null
             $cg.IsValid() | Should -BeFalse
         }
+
+        It 'Returns $true for an AllOf group condition' {
+            $cg = [ConditionGroup]::new(@{
+                AllOf = @(
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' }
+                )
+            })
+            $cg.IsValid() | Should -BeTrue
+        }
+
+        It 'Returns $true for an AnyOf group condition' {
+            $cg = [ConditionGroup]::new(@{
+                AnyOf = @(
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Staging' },
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' }
+                )
+            })
+            $cg.IsValid() | Should -BeTrue
+        }
+
+        It 'Returns $true for a Not group condition' {
+            $cg = [ConditionGroup]::new(@{
+                Not = @(
+                    @{ Property = 'Environment'; Operator = 'Equals'; Value = 'Production' }
+                )
+            })
+            $cg.IsValid() | Should -BeTrue
+        }
     }
 
     Describe 'ToString' {


### PR DESCRIPTION
Fixes #31.

`IsValid()` only checked for `Property`, `Operator`, and `Value` being non-null, so it always returned `\False` for group conditions (AllOf/AnyOf/Not) even when they were perfectly well-formed.

Extended `IsValid()` to also return `\True` when any of the group fields (AllOf/AnyOf/Not) are set, preserving existing leaf-condition behavior. Added three new tests covering AllOf, AnyOf, and Not groups.