### PR TITLE
refactor(cmdletbinding): add [CmdletBinding()] to four functions

### DIFF
--- a/Gatekeeper/Private/Convert-ToTypedValue.ps1
+++ b/Gatekeeper/Private/Convert-ToTypedValue.ps1
@@ -1,4 +1,5 @@
 function Convert-ToTypedValue {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
         [string]

--- a/Gatekeeper/Private/Invoke-Logging.ps1
+++ b/Gatekeeper/Private/Invoke-Logging.ps1
@@ -1,4 +1,5 @@
 function Invoke-Logging {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
         [Effect]

--- a/Gatekeeper/Private/Test-TypedValue.ps1
+++ b/Gatekeeper/Private/Test-TypedValue.ps1
@@ -1,4 +1,5 @@
 function Test-TypedValue {
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
         $Value,

--- a/Gatekeeper/Public/Test-Condition.ps1
+++ b/Gatekeeper/Public/Test-Condition.ps1
@@ -29,6 +29,7 @@ function Test-Condition {
 
     This would return a true/false
     #>
+    [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
         [hashtable]


### PR DESCRIPTION
Fixes #32.

Added `[CmdletBinding()]` to the four functions missing it:

- `Public/Test-Condition.ps1` — only public function without it; gains `-Verbose`/`-ErrorAction` support
- `Private/Test-TypedValue.ps1` — was using `$PSCmdlet.ParameterSetName` without `[CmdletBinding()]` (worked accidentally via dynamic parameter binding)
- `Private/Invoke-Logging.ps1` — had `begin`/`process` blocks without `[CmdletBinding()]`; blocks had no pipeline effect
- `Private/Convert-ToTypedValue.ps1` — added for consistency

No behavioral changes other than the fixes above. All 370 tests pass.