### PR TITLE
fix(Test-Condition): remove dead variable

### DIFF
--- a/Gatekeeper/Public/Test-Condition.ps1
+++ b/Gatekeeper/Public/Test-Condition.ps1
@@ -88,7 +88,6 @@ function Test-Condition {
 
     $meta = $PropertySet.GetProperty($propName)
     $propType = $meta.Type
-    $validation = $meta.Validation
 
     $actual = Convert-ToTypedValue -Type $propType -Value $Context[$propName]
     $valid = $meta.Validate($actual)


### PR DESCRIPTION
Fixes #33.

Removed unused $validation variable assignment from Test-Condition.ps1 line 91. The variable was assigned from $meta.Validation but never referenced in the function. The metadata object is still used for validation via $meta.Validate().

## Test plan

- [x] All 370 tests pass
- [x] No PSScriptAnalyzer warnings introduced
- [x] Functionality unchanged