### PR TITLE
fix(classes): use atomic write in FeatureFlag.Save and PropertySet.Save

### DIFF
--- a/Gatekeeper/Classes/FeatureFlag.ps1
+++ b/Gatekeeper/Classes/FeatureFlag.ps1
@@ -213,7 +213,9 @@ class FeatureFlag {
             $jsonParams['EnumsAsStrings'] = $true
         }
         $json = $this | ConvertTo-Json @jsonParams
-        Set-Content -Path $this.FilePath -Value $json
+        $tmpPath = "$($this.FilePath).tmp"
+        Set-Content -Path $tmpPath -Value $json
+        Move-Item -Path $tmpPath -Destination $this.FilePath -Force
     }
 }
 

--- a/Gatekeeper/Classes/Property.ps1
+++ b/Gatekeeper/Classes/Property.ps1
@@ -184,7 +184,9 @@ class PropertySet {
         }
         # Convert to JSON with a depth of 10 to handle nested objects
         $json = $hashtable | ConvertTo-Json -Depth 10
-        Set-Content -Path $this.FilePath -Value $json
+        $tmpPath = "$($this.FilePath).tmp"
+        Set-Content -Path $tmpPath -Value $json
+        Move-Item -Path $tmpPath -Destination $this.FilePath -Force
     }
 }
 


### PR DESCRIPTION
Fixes #37.

Both `Save` methods previously wrote directly to the target file with `Set-Content`, leaving the file in a corrupt state if the process crashed mid-write. This replaces the direct write with a write-to-temp-then-rename pattern: the JSON is written to `<path>.tmp` and then atomically moved into place via `Move-Item -Force`. Applied to both `FeatureFlag.Save` and `PropertySet.Save`.