### PR TITLE
docs(help): fill unrendered PlatyPS scaffolding in external help files

### DIFF
--- a/docs/en-US/Get-FeatureFlagFolder.md
+++ b/docs/en-US/Get-FeatureFlagFolder.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-FeatureFlagFolder
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Return the folder path where feature flag JSON files are stored.
 
 ## SYNTAX
 
@@ -17,16 +17,19 @@ Get-FeatureFlagFolder [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Returns the configured folder path for feature flag JSON files. If no path has been
+configured yet, a default path is created under the machine-wide configuration
+location and saved to the Gatekeeper configuration.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+$folder = Get-FeatureFlagFolder
+Get-ChildItem -Path $folder -Filter '*.json'
 ```
 
-{{ Add example description here }}
+Returns the feature flag folder path and lists all flag files in it.
 
 ## PARAMETERS
 
@@ -54,7 +57,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Object
+### System.String
+
+The absolute path to the feature flag folder.
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/en-US/Get-PropertySetFolder.md
+++ b/docs/en-US/Get-PropertySetFolder.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-PropertySetFolder
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Return the folder path where property set JSON files are stored.
 
 ## SYNTAX
 
@@ -17,16 +17,19 @@ Get-PropertySetFolder [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Returns the configured folder path for property set JSON files. If no path has been
+configured yet, a default path is created under the machine-wide configuration
+location and saved to the Gatekeeper configuration.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+$folder = Get-PropertySetFolder
+Get-ChildItem -Path $folder -Filter '*.json'
 ```
 
-{{ Add example description here }}
+Returns the property set folder path and lists all property set files in it.
 
 ## PARAMETERS
 
@@ -54,7 +57,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Object
+### System.String
+
+The absolute path to the property set folder.
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/en-US/Import-GatekeeperConfig.md
+++ b/docs/en-US/Import-GatekeeperConfig.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Import-GatekeeperConfig
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Load and cache the Gatekeeper module configuration.
 
 ## SYNTAX
 
@@ -17,21 +17,31 @@ Import-GatekeeperConfig [-ForceReload] [-ProgressAction <ActionPreference>] [<Co
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+Reads the Gatekeeper configuration from disk using the Configuration module and caches
+it in the module-scoped `$GatekeeperConfiguration` variable. Subsequent calls return the
+cached copy unless `-ForceReload` is specified. Also parses and compiles the logging
+configuration into ready-to-invoke script blocks.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+Import-GatekeeperConfig
 ```
 
-{{ Add example description here }}
+Loads the Gatekeeper configuration from disk and caches it for the session.
+
+### Example 2
+```powershell
+Import-GatekeeperConfig -ForceReload
+```
+
+Discards the cached configuration and reloads it from disk.
 
 ## PARAMETERS
 
 ### -ForceReload
-{{ Fill ForceReload Description }}
+Clears the cached configuration and reloads it from disk.
 
 ```yaml
 Type: SwitchParameter
@@ -69,7 +79,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Object
+### System.Collections.Hashtable
+
+The loaded configuration hashtable.
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/en-US/New-Condition.md
+++ b/docs/en-US/New-Condition.md
@@ -131,6 +131,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-General notes
 
 ## RELATED LINKS

--- a/docs/en-US/New-ConditionGroup.md
+++ b/docs/en-US/New-ConditionGroup.md
@@ -116,6 +116,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ## NOTES
-General notes
 
 ## RELATED LINKS

--- a/docs/en-US/Test-Condition.md
+++ b/docs/en-US/Test-Condition.md
@@ -51,7 +51,7 @@ Accept wildcard characters: False
 ```
 
 ### -PropertySet
-{{ Fill PropertySet Description }}
+The PropertySet that defines the valid properties and their types for the given context.
 
 ```yaml
 Type: PropertySet


### PR DESCRIPTION
Fixes #39.

Replaces every `{{ Fill ... }}` mustache token in the six affected docs with real content derived from reading the source functions:

- `Import-GatekeeperConfig.md` — fully unrendered; filled synopsis, description, two examples, ForceReload description, and corrected output type.
- `Get-FeatureFlagFolder.md` — fully unrendered; filled synopsis, description, example, and corrected output type.
- `Get-PropertySetFolder.md` — fully unrendered; filled synopsis, description, example, and corrected output type.
- `Test-Condition.md` — filled `{{ Fill PropertySet Description }}` placeholder.
- `New-Condition.md` — removed `General notes` placeholder from `## NOTES`.
- `New-ConditionGroup.md` — same.

Tests: 370 passed, 0 failed.