### PR TITLE
docs(public): add comment-based help to folder and config functions

### DIFF
--- a/Gatekeeper/Public/Get-FeatureFlagFolder.ps1
+++ b/Gatekeeper/Public/Get-FeatureFlagFolder.ps1
@@ -1,5 +1,30 @@
 #requires -Module Configuration
 function Get-FeatureFlagFolder {
+    <#
+    .SYNOPSIS
+    Returns the configured directory where feature flag JSON files are stored.
+
+    .DESCRIPTION
+    Retrieves the feature flag folder path from the active Gatekeeper configuration.
+    If no path has been configured, a default location is created under the machine-wide
+    configuration path and saved automatically via Export-GatekeeperConfig.
+
+    Use Export-GatekeeperConfig to set the path explicitly and avoid the auto-create
+    behavior on first run.
+
+    .OUTPUTS
+    System.String
+
+    .EXAMPLE
+    $folder = Get-FeatureFlagFolder
+    Get-ChildItem -Path $folder -Filter '*.json'
+
+    Returns the feature flag folder path and lists all JSON files in it.
+
+    .NOTES
+    On first run, if no path is configured, this function creates the default directory
+    and persists the path to configuration automatically.
+    #>
     [CmdletBinding()]
     param ()
 

--- a/Gatekeeper/Public/Get-PropertySetFolder.ps1
+++ b/Gatekeeper/Public/Get-PropertySetFolder.ps1
@@ -1,5 +1,30 @@
 #requires -Module Configuration
 function Get-PropertySetFolder {
+    <#
+    .SYNOPSIS
+    Returns the configured directory where property set JSON files are stored.
+
+    .DESCRIPTION
+    Retrieves the property set folder path from the active Gatekeeper configuration.
+    If no path has been configured, a default location is created under the machine-wide
+    configuration path and saved automatically via Export-GatekeeperConfig.
+
+    Use Export-GatekeeperConfig to set the path explicitly and avoid the auto-create
+    behavior on first run.
+
+    .OUTPUTS
+    System.String
+
+    .EXAMPLE
+    $folder = Get-PropertySetFolder
+    Get-ChildItem -Path $folder -Filter '*.json'
+
+    Returns the property set folder path and lists all JSON files in it.
+
+    .NOTES
+    On first run, if no path is configured, this function creates the default directory
+    and persists the path to configuration automatically.
+    #>
     [CmdletBinding()]
     param ()
 

--- a/Gatekeeper/Public/Import-GatekeeperConfig.ps1
+++ b/Gatekeeper/Public/Import-GatekeeperConfig.ps1
@@ -1,4 +1,34 @@
 function Import-GatekeeperConfig {
+    <#
+    .SYNOPSIS
+    Loads the Gatekeeper module configuration with multi-level precedence.
+
+    .DESCRIPTION
+    Imports the Gatekeeper configuration using the Configuration module's precedence
+    chain: module defaults, machine-wide settings, enterprise roaming settings, and
+    user local settings. The result is cached in module scope so subsequent calls
+    return quickly without re-reading disk.
+
+    Logging scripts defined in the configuration are parsed and stored in
+    $script:GatekeeperLogging. Scripts may be inline scriptblocks, inline PowerShell
+    strings, or paths to local .ps1 files. UNC and remote paths are rejected.
+
+    .PARAMETER ForceReload
+    Clears the module-scope cache and re-reads configuration from disk.
+
+    .OUTPUTS
+    System.Collections.Hashtable
+
+    .EXAMPLE
+    Import-GatekeeperConfig
+
+    Returns the cached configuration, loading from disk on first call.
+
+    .EXAMPLE
+    Import-GatekeeperConfig -ForceReload
+
+    Discards the cached configuration and reloads from disk.
+    #>
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]


### PR DESCRIPTION
Fixes #40.

Adds `.SYNOPSIS`, `.DESCRIPTION`, `.OUTPUTS`, `.EXAMPLE`, and `.NOTES` comment-based help blocks to the three public functions that had none:

- `Get-FeatureFlagFolder` — documents the return value and the first-run auto-create/persist side effect
- `Get-PropertySetFolder` — same treatment as above
- `Import-GatekeeperConfig` — documents the multi-level precedence loading, the module-scope cache, `-ForceReload`, and the `$script:GatekeeperLogging` population

No logic was changed. All 370 tests pass.