### PR TITLE
docs(Test-FeatureFlag,Test-Condition): add [OutputType([bool])] and .OUTPUTS help

### DIFF
--- a/Gatekeeper/Public/Test-Condition.ps1
+++ b/Gatekeeper/Public/Test-Condition.ps1
@@ -28,8 +28,13 @@ function Test-Condition {
     Test-Condition -Context $context -PropertySet $propertySet -Condition $rule
 
     This would return a true/false
+
+    .OUTPUTS
+    System.Boolean
+    Returns $true if the condition matches the given context, $false otherwise.
     #>
     [CmdletBinding()]
+    [OutputType([bool])]
     param (
         [Parameter(Mandatory)]
         [hashtable]

--- a/Gatekeeper/Public/Test-FeatureFlag.ps1
+++ b/Gatekeeper/Public/Test-FeatureFlag.ps1
@@ -24,8 +24,13 @@
     Test-FeatureFlag -FeatureFlag $flag -PropertySet $propertySet -Context $context
 
     This will test if the current device will pass the feature flag rules.
+
+    .OUTPUTS
+    System.Boolean
+    Returns $true if an Allow rule matches, $false otherwise.
     #>
     [CmdletBinding()]
+    [OutputType([bool])]
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
         [FeatureFlag]

--- a/docs/en-US/Test-Condition.md
+++ b/docs/en-US/Test-Condition.md
@@ -102,6 +102,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.Boolean
+
+Returns $true if the condition matches the given context, $false otherwise.
+
 ## NOTES
 
 ## RELATED LINKS

--- a/docs/en-US/Test-FeatureFlag.md
+++ b/docs/en-US/Test-FeatureFlag.md
@@ -101,6 +101,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.Boolean
+
+Returns $true if an Allow rule matches, $false otherwise.
+
 ## NOTES
 
 ## RELATED LINKS


### PR DESCRIPTION
Fixes #42.

Added `[OutputType([bool])]` attribute and `.OUTPUTS` help block to both `Test-FeatureFlag` and `Test-Condition`. Also populated the `## OUTPUTS` section in the PlatyPS markdown files for both commands.

- `Test-FeatureFlag`: returns `$true` if an Allow rule matches, `$false` otherwise
- `Test-Condition`: returns `$true` if the condition matches the given context, `$false` otherwise

All 373 tests pass.