### PR TITLE
refactor(workflow): replace isPrerelease with force, normalise expressions

### DIFF
--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -9,8 +9,8 @@ on:
         description: "The version to publish. Leave empty to use the version in the module manifest."
         required: false
         type: string
-      isPrerelease:
-        description: "Is this a prerelease version?"
+      force:
+        description: "If true, bypass the PSGallery version existence check. Use when re-triggering a failed publish job (pattern: force=true, create_release=false, publish=true)."
         required: false
         type: boolean
         default: false
@@ -37,9 +37,8 @@ jobs:
     uses: HeyItsGilbert/.github/.github/workflows/PublishModule.yml@main
     with:
       version: ${{ inputs.version || '' }}
-      isPrerelease: ${{ inputs.isPrerelease || false }}
+      force: ${{ inputs.force || false }}
       dry_run: ${{ inputs.dry_run || false }}
-      create_release: ${{ github.event_name == 'push' || inputs.create_release }}
-      publish: ${{ github.event_name == 'push' || inputs.publish }}
+      create_release: ${{ github.event_name != 'workflow_dispatch' || inputs.create_release }}
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
     secrets: inherit
-


### PR DESCRIPTION
@
Aligns with HeyItsGilbert/.github#1.

- Removes `isPrerelease` — the reusable workflow now infers prerelease from `PSData.Prerelease` in the manifest
- Adds `force` to bypass the PSGallery existence check when re-triggering a failed job
- Normalises `create_release`/`publish` expressions to `github.event_name != workflow_dispatch || inputs.X`

Re-trigger pattern: `force=true, create_release=false, publish=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@